### PR TITLE
Configure Travis to run tests in node 0.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "0.10"
+script:
+  - "./script/ci-test.sh"
+

--- a/script/ci-test.sh
+++ b/script/ci-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eu
+
+npm run test-node
+npm run test-headless


### PR DESCRIPTION
Some of the devDependencies doesn't work with node 0.8.x and 0.6.x, and we'll be running tests in browsers anyway. Developers can be expected to keep up to date and use modern node environments. There are no non-dev dependencies that require older node.
