### PR TITLE
Fix overwriting custom `Date.now`, related to Sinon.JS issue 624

### DIFF
--- a/src/lolex.js
+++ b/src/lolex.js
@@ -68,7 +68,13 @@
 
     function mirrorDateProperties(target, source) {
         var prop;
+        for (prop in source) {
+            if (source.hasOwnProperty(prop)) {
+                target[prop] = source[prop];
+            }
+        }
 
+        // set special now implementation
         if (source.now) {
             target.now = function now() {
                 return target.clock.now;
@@ -77,6 +83,7 @@
             delete target.now;
         }
 
+        // set special toSource implementation
         if (source.toSource) {
             target.toSource = function toSource() {
                 return source.toSource();
@@ -85,6 +92,7 @@
             delete target.toSource;
         }
 
+        // set special toString implementation
         target.toString = function toString() {
             return source.toString();
         };
@@ -93,12 +101,6 @@
         target.parse = source.parse;
         target.UTC = source.UTC;
         target.prototype.toUTCString = source.prototype.toUTCString;
-
-        for (prop in source) {
-            if (source.hasOwnProperty(prop)) {
-                target[prop] = source[prop];
-            }
-        }
 
         return target;
     }


### PR DESCRIPTION
By first copying all the properties from `source` to `target` and only then setting specific functions for `now`, `toSource` and `toString`, we're not overwriting the custom implementation of those with the ones
from `source`.

Previously, the `for-in` at the end of the function, would overwrite the `now` function that we just created.

This is related to https://github.com/cjohansen/Sinon.JS/issues/624, however there seems to be more things in play here.
