### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,7 @@
     "mail": "christian@cjohansen.no",
     "url": "http://github.com/sinonjs/lolex/issues"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/sinonjs/lolex/blob/master/LICENSE"
-    }
-  ],
+  "license": "BSD",
   "scripts": {
     "lint": "$(npm bin)/jslint src/**/*.js",
     "test-node": "mocha -R dot",


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license