### PR TITLE
Fix complaint about missing fake setImmediate

### DIFF
--- a/src/lolex.js
+++ b/src/lolex.js
@@ -435,11 +435,11 @@
     function detectKnownFailSituation(methods) {
         if (methods.indexOf("Date") < 0) { return; }
 
-        if (methods.indexOf("setTimeout") < 0) {
+        if (typeof setTimeout !== "undefined" && methods.indexOf("setTimeout") < 0) {
             throw new Error("Native setTimeout will not work when Date is faked");
         }
 
-        if (methods.indexOf("setImmediate") < 0) {
+        if (typeof setImmediate !== "undefined" && methods.indexOf("setImmediate") < 0) {
             throw new Error("Native setImmediate will not work when Date is faked");
         }
     }


### PR DESCRIPTION
Only throw `Error` about `setImmediate` not being faked, when there is a `setImmediate` function to fake.

Once a new version is baked with this fix, we update `lolex` in Sinon.JS and can fix https://github.com/cjohansen/Sinon.JS/issues/786