### PR TITLE
Fix for Sinon.JS issue #766: clearTimeout() no longer clears Immediat…

### DIFF
--- a/src/lolex.js
+++ b/src/lolex.js
@@ -260,11 +260,11 @@
 
     function timerType(timer) {
         if (timer.immediate) {
-            return "immediate";
+            return "Immediate";
         } else if (typeof timer.interval !== "undefined") {
-            return "interval";
+            return "Interval";
         } else {
-            return "timeout";
+            return "Timeout";
         }
     }
 
@@ -290,7 +290,9 @@
             var timer = clock.timers[timerId];
             if (timerType(timer) === ttype) {
                 delete clock.timers[timerId];
-            }
+            } else {
+				throw new Error("Cannot clear timer: timer created with set" + ttype + "() but cleared with clear" + timerType(timer) + "()");
+			}
         }
     }
 
@@ -382,7 +384,7 @@
         };
 
         clock.clearTimeout = function clearTimeout(timerId) {
-            return clearTimer(clock, timerId, "timeout");
+            return clearTimer(clock, timerId, "Timeout");
         };
 
         clock.setInterval = function setInterval(func, timeout) {
@@ -395,7 +397,7 @@
         };
 
         clock.clearInterval = function clearInterval(timerId) {
-            return clearTimer(clock, timerId, "interval");
+            return clearTimer(clock, timerId, "Interval");
         };
 
         clock.setImmediate = function setImmediate(func) {
@@ -407,7 +409,7 @@
         };
 
         clock.clearImmediate = function clearImmediate(timerId) {
-            return clearTimer(clock, timerId, "immediate");
+            return clearTimer(clock, timerId, "Immediate");
         };
 
         clock.tick = function tick(ms) {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -117,7 +117,7 @@ describe("lolex", function () {
         });
     });
 
-    describe("setImmediate", function () {
+     describe("setImmediate", function () {
 
         beforeEach(function () {
             this.clock = lolex.createClock();
@@ -211,6 +211,27 @@ describe("lolex", function () {
 
             assert.isFalse(callback.called);
         });
+
+        it("does not remove timeout", function () {
+            var callback = sinon.stub();
+
+            var id = this.clock.setTimeout(callback, 50);
+            this.clock.clearImmediate(id);
+            this.clock.tick(55);
+
+            assert.isTrue(callback.called);
+        });
+
+        it("does not remove interval", function () {
+            var callback = sinon.stub();
+
+            var id = this.clock.setInterval(callback, 50);
+            this.clock.clearImmediate(id);
+            this.clock.tick(55);
+
+            assert.isTrue(callback.called);
+        });
+
     });
 
     describe("tick", function () {
@@ -434,7 +455,7 @@ describe("lolex", function () {
             var id;
             var callback = sinon.spy(function () {
                 if (callback.callCount === 3) {
-                    clearTimeout(id);
+                    clearInterval(id);
                 }
             });
 
@@ -565,6 +586,24 @@ describe("lolex", function () {
             assert.isFalse(stub.called);
         });
 
+        it("does not remove interval", function () {
+            var stub = sinon.stub();
+            var id = this.clock.setInterval(stub, 50);
+            this.clock.clearTimeout(id);
+            this.clock.tick(50);
+
+            assert.isTrue(stub.called);
+        });
+
+        it("does not remove immediate", function () {
+            var stub = sinon.stub();
+            var id = this.clock.setImmediate(stub);
+            this.clock.clearTimeout(id);
+            this.clock.tick(50);
+
+            assert.isTrue(stub.called);
+        });
+
         it("ignores null argument", function () {
             this.clock.clearTimeout(null);
             assert(true); // doesn't fail
@@ -650,6 +689,45 @@ describe("lolex", function () {
             clock.tick(3);
 
             assert.isTrue(stub.calledWithExactly("the first", "the second"));
+        });
+    });
+
+    describe("clearInterval", function () {
+
+        beforeEach(function () {
+            this.clock = lolex.createClock();
+        });
+
+        it("removes interval", function () {
+            var stub = sinon.stub();
+            var id = this.clock.setInterval(stub, 50);
+            this.clock.clearInterval(id);
+            this.clock.tick(50);
+
+            assert.isFalse(stub.called);
+        });
+
+        it("does not remove timeout", function () {
+            var stub = sinon.stub();
+            var id = this.clock.setTimeout(stub, 50);
+            this.clock.clearInterval(id);
+            this.clock.tick(50);
+
+            assert.isTrue(stub.called);
+        });
+
+        it("does not remove immediate", function () {
+            var stub = sinon.stub();
+            var id = this.clock.setImmediate(stub);
+            this.clock.clearInterval(id);
+            this.clock.tick(50);
+
+            assert.isTrue(stub.called);
+        });
+
+        it("ignores null argument", function () {
+            this.clock.clearInterval(null);
+            assert(true); // doesn't fail
         });
     });
 

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -216,7 +216,9 @@ describe("lolex", function () {
             var callback = sinon.stub();
 
             var id = this.clock.setTimeout(callback, 50);
-            this.clock.clearImmediate(id);
+            assert.exception(function() {
+                this.clock.clearImmediate(id);
+            });
             this.clock.tick(55);
 
             assert.isTrue(callback.called);
@@ -226,7 +228,9 @@ describe("lolex", function () {
             var callback = sinon.stub();
 
             var id = this.clock.setInterval(callback, 50);
-            this.clock.clearImmediate(id);
+            assert.exception(function() {
+                this.clock.clearImmediate(id);
+            });
             this.clock.tick(55);
 
             assert.isTrue(callback.called);
@@ -589,7 +593,9 @@ describe("lolex", function () {
         it("does not remove interval", function () {
             var stub = sinon.stub();
             var id = this.clock.setInterval(stub, 50);
-            this.clock.clearTimeout(id);
+            assert.exception(function() {
+                this.clock.clearTimeout(id);
+            });
             this.clock.tick(50);
 
             assert.isTrue(stub.called);
@@ -598,7 +604,9 @@ describe("lolex", function () {
         it("does not remove immediate", function () {
             var stub = sinon.stub();
             var id = this.clock.setImmediate(stub);
-            this.clock.clearTimeout(id);
+            assert.exception(function() {
+                this.clock.clearTimeout(id);
+            });
             this.clock.tick(50);
 
             assert.isTrue(stub.called);
@@ -710,16 +718,19 @@ describe("lolex", function () {
         it("does not remove timeout", function () {
             var stub = sinon.stub();
             var id = this.clock.setTimeout(stub, 50);
-            this.clock.clearInterval(id);
+            assert.exception(function() {
+                this.clock.clearInterval(id);
+            });
             this.clock.tick(50);
-
             assert.isTrue(stub.called);
         });
 
         it("does not remove immediate", function () {
             var stub = sinon.stub();
             var id = this.clock.setImmediate(stub);
-            this.clock.clearInterval(id);
+            assert.exception(function() {
+                this.clock.clearInterval(id);
+            });
             this.clock.tick(50);
 
             assert.isTrue(stub.called);


### PR DESCRIPTION
…e/Interval and vice versa

A clearTimeout(), given the ID of a timer started with setImmediate() or
setInterval() would erroneously clear that immediate or interval