### PR TITLE
Fix for Sinon.JS issue #808: add setSystemTime() function

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,10 @@ var clock = lolex.install();
 
 ### `clock.tick(time)`
 
+### `clock.setSystemTime([now])`
+This simulates a user changing the system clock while your program is running.
+It affects the current time but it does not in itself cause e.g. timers to fire; they will fire exactly as they would have done without the call to setSystemTime().
+
 ### `clock.uninstall()`
 
 ### `Date`

--- a/src/lolex.js
+++ b/src/lolex.js
@@ -396,6 +396,7 @@
             ms = typeof ms === "number" ? ms : parseTime(ms);
             var tickFrom = clock.now, tickTo = clock.now + ms, previous = clock.now;
             var timer = firstTimerInRange(clock, tickFrom, tickTo);
+            var oldNow;
 
             clock.duringTick = true;
 
@@ -404,7 +405,14 @@
                 if (clock.timers[timer.id]) {
                     tickFrom = clock.now = timer.callAt;
                     try {
+                        oldNow = clock.now;
                         callTimer(clock, timer);
+                        // compensate for any setSystemTime() call during timer callback
+                        if (oldNow !== clock.now) {
+                            tickFrom += clock.now - oldNow;
+                            tickTo += clock.now - oldNow;
+                            previous += clock.now - oldNow;
+                        }
                     } catch (e) {
                         firstException = firstException || e;
                     }
@@ -426,6 +434,24 @@
 
         clock.reset = function reset() {
             clock.timers = {};
+        };
+
+        clock.setSystemTime = function setSystemTime(now) {
+            // determine time difference
+            var newNow = getEpoch(now);
+            var difference = newNow - clock.now;
+
+            // update 'system clock'
+            clock.now = newNow;
+            
+            // update timers and intervals to keep them stable
+            for (var id in clock.timers) {
+                if (clock.timers.hasOwnProperty(id)) {
+                    var timer = clock.timers[id];
+                    timer.createdAt += difference;
+                    timer.callAt += difference;
+                }
+            }
         };
 
         return clock;

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -115,6 +115,28 @@ describe("lolex", function () {
             clock.tick(100);
             assert(stub.called);
         });
+
+        it("is not influenced by forward system clock changes", function () {
+            var stub = sinon.stub();
+            this.clock.setTimeout(stub, 5000);
+            this.clock.tick(1000);
+            this.clock.setSystemTime((new this.clock.Date()).getTime() + 1000);
+            this.clock.tick(3990);
+            assert.equals(stub.callCount, 0);
+            this.clock.tick(20);
+            assert.equals(stub.callCount, 1);
+        });
+
+        it("is not influenced by backward system clock changes", function () {
+            var stub = sinon.stub();
+            this.clock.setTimeout(stub, 5000);
+            this.clock.tick(1000);
+            this.clock.setSystemTime((new this.clock.Date()).getTime() - 1000);
+            this.clock.tick(3990);
+            assert.equals(stub.callCount, 0);
+            this.clock.tick(20);
+            assert.equals(stub.callCount, 1);
+        });
     });
 
     describe("setImmediate", function () {
@@ -626,6 +648,29 @@ describe("lolex", function () {
             assert.equals(stub.callCount, 9);
         });
 
+        it("is not influenced by forward system clock changes", function () {
+            var stub = sinon.stub();
+            this.clock.setInterval(stub, 10);
+            this.clock.tick(11);
+            assert.equals(stub.callCount, 1);
+            this.clock.setSystemTime((new this.clock.Date()).getTime() + 1000);
+            this.clock.tick(8);
+            assert.equals(stub.callCount, 1);
+            this.clock.tick(3);
+            assert.equals(stub.callCount, 2);
+        });
+
+        it("is not influenced by backward system clock changes", function () {
+            var stub = sinon.stub();
+            this.clock.setInterval(stub, 10);
+            this.clock.tick(5);
+            this.clock.setSystemTime((new this.clock.Date()).getTime() - 1000);
+            this.clock.tick(6);
+            assert.equals(stub.callCount, 1);
+            this.clock.tick(10);
+            assert.equals(stub.callCount, 2);
+        });
+
         it("does not schedule recurring timeout when cleared", function () {
             var clock = this.clock;
             var id;
@@ -709,6 +754,14 @@ describe("lolex", function () {
             var date2 = new this.clock.Date();
 
             assert.equals(date2.getTime() - date1.getTime(), 3);
+        });
+
+        it("listens to system clock changes", function () {
+            var date1 = new this.clock.Date();
+            this.clock.setSystemTime(date1.getTime() + 1000);
+            var date2 = new this.clock.Date();
+
+            assert.equals(date2.getTime() - date1.getTime(), 1000);
         });
 
         it("creates regular date when passing timestamp", function () {


### PR DESCRIPTION
setSystemTime() changes the current time while ensuring that the behavior of any existing timers doesn't change. It simulates the user changing the system clock while the program-under-test is running.