### PR TITLE
Fix for breaking setImmediate polyfills

### DIFF
--- a/src/lolex.js
+++ b/src/lolex.js
@@ -16,11 +16,16 @@
 
     global.setTimeout = glbl.setTimeout;
     global.clearTimeout = glbl.clearTimeout;
-    global.setImmediate = glbl.setImmediate;
-    global.clearImmediate = glbl.clearImmediate;
     global.setInterval = glbl.setInterval;
     global.clearInterval = glbl.clearInterval;
     global.Date = glbl.Date;
+
+    // setImmediate is not a standard function
+    // avoid adding the prop to the window object if not present
+    if('setImmediate' in global) {
+        global.setImmediate = glbl.setImmediate;
+        global.clearImmediate = glbl.clearImmediate;
+    }
 
     // node expects setTimeout/setInterval to return a fn object w/ .ref()/.unref()
     // browsers, a number.


### PR DESCRIPTION
When binding the original native functions to the global object to make them writable in IE, `lolex` assigns setImmediate no matter if it is present as a native browser function or not. That made some polyfills fail, as they would add the polyfill to the _prototype of window_, not the window object itself. Thus, the property added by `lolex` would shadow that of the prototype.

The fix simply checks if the property is present beforeadding it.

Should implicitly fix issue cjohansen/Sinon.JS#821

Verify problem was introduced in 4aec26199f14df8bca46d300811cfcf9ec03ccc3
```
git clone  git@github.com:sinonjs/lolex.git 
cd lolex
curl -o test-script.sh https://raw.githubusercontent.com/fatso83/lolex/setImmediate-shim-bug/test-script.sh
git bisect start v1.2.1 v1.2.0  && git bisect run sh test-script.sh
```
produces 
> 4aec26199f14df8bca46d300811cfcf9ec03ccc3 is the first bad commit

The test [run by `test-script.sh`](https://github.com/fatso83/lolex/tree/setImmediate-shim-bug) breaks in IE9, Chrome and PhantomJS.

After the fix the test passes in all current browsers (including Chrome Canary 47.0.2503).