### PR TITLE
Fix lint errors

### DIFF
--- a/script/ci-test.sh
+++ b/script/ci-test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
+npm run lint
 npm run test-node
 npm run test-headless

--- a/src/lolex.js
+++ b/src/lolex.js
@@ -22,7 +22,7 @@
 
     // setImmediate is not a standard function
     // avoid adding the prop to the window object if not present
-    if('setImmediate' in global) {
+    if (global.setImmediate !== undefined) {
         global.setImmediate = glbl.setImmediate;
         global.clearImmediate = glbl.clearImmediate;
     }
@@ -266,11 +266,11 @@
     function timerType(timer) {
         if (timer.immediate) {
             return "Immediate";
-        } else if (typeof timer.interval !== "undefined") {
-            return "Interval";
-        } else {
-            return "Timeout";
         }
+        if (timer.interval !== undefined) {
+            return "Interval";
+        }
+        return "Timeout";
     }
 
     function clearTimer(clock, timerId, ttype) {
@@ -296,8 +296,8 @@
             if (timerType(timer) === ttype) {
                 delete clock.timers[timerId];
             } else {
-				throw new Error("Cannot clear timer: timer created with set" + ttype + "() but cleared with clear" + timerType(timer) + "()");
-			}
+                throw new Error("Cannot clear timer: timer created with set" + ttype + "() but cleared with clear" + timerType(timer) + "()");
+            }
         }
     }
 
@@ -465,14 +465,15 @@
             // determine time difference
             var newNow = getEpoch(now);
             var difference = newNow - clock.now;
+            var id, timer;
 
             // update 'system clock'
             clock.now = newNow;
 
             // update timers and intervals to keep them stable
-            for (var id in clock.timers) {
+            for (id in clock.timers) {
                 if (clock.timers.hasOwnProperty(id)) {
-                    var timer = clock.timers[id];
+                    timer = clock.timers[id];
                     timer.createdAt += difference;
                     timer.callAt += difference;
                 }

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -5,6 +5,9 @@
     it,
     assert
 */
+/*jslint
+    todo:true
+*/
 /**
  * @author Christian Johansen (christian@cjohansen.no)
  * @license BSD
@@ -139,7 +142,7 @@ describe("lolex", function () {
         });
     });
 
-     describe("setImmediate", function () {
+    describe("setImmediate", function () {
 
         beforeEach(function () {
             this.clock = lolex.createClock();
@@ -238,7 +241,7 @@ describe("lolex", function () {
             var callback = sinon.stub();
 
             var id = this.clock.setTimeout(callback, 50);
-            assert.exception(function() {
+            assert.exception(function () {
                 this.clock.clearImmediate(id);
             });
             this.clock.tick(55);
@@ -250,7 +253,7 @@ describe("lolex", function () {
             var callback = sinon.stub();
 
             var id = this.clock.setInterval(callback, 50);
-            assert.exception(function() {
+            assert.exception(function () {
                 this.clock.clearImmediate(id);
             });
             this.clock.tick(55);
@@ -615,7 +618,7 @@ describe("lolex", function () {
         it("does not remove interval", function () {
             var stub = sinon.stub();
             var id = this.clock.setInterval(stub, 50);
-            assert.exception(function() {
+            assert.exception(function () {
                 this.clock.clearTimeout(id);
             });
             this.clock.tick(50);
@@ -626,7 +629,7 @@ describe("lolex", function () {
         it("does not remove immediate", function () {
             var stub = sinon.stub();
             var id = this.clock.setImmediate(stub);
-            assert.exception(function() {
+            assert.exception(function () {
                 this.clock.clearTimeout(id);
             });
             this.clock.tick(50);
@@ -763,7 +766,7 @@ describe("lolex", function () {
         it("does not remove timeout", function () {
             var stub = sinon.stub();
             var id = this.clock.setTimeout(stub, 50);
-            assert.exception(function() {
+            assert.exception(function () {
                 this.clock.clearInterval(id);
             });
             this.clock.tick(50);
@@ -773,7 +776,7 @@ describe("lolex", function () {
         it("does not remove immediate", function () {
             var stub = sinon.stub();
             var id = this.clock.setImmediate(stub);
-            assert.exception(function() {
+            assert.exception(function () {
                 this.clock.clearInterval(id);
             });
             this.clock.tick(50);
@@ -817,6 +820,7 @@ describe("lolex", function () {
 
         it("creates real Date objects when Date constructor is gone", function () {
             var realDate = new Date();
+            // Comment out the next line for jslint to be "happy".
             Date = NOOP;
             global.Date = NOOP;
 
@@ -1148,6 +1152,7 @@ describe("lolex", function () {
             assert.same(clearInterval, lolex.timers.clearInterval);
         });
 
+        // Comment out the next block for jslint to be "happy".
         if (global.__proto__) {
             delete global.hasOwnPropertyTest;
             global.__proto__.hasOwnPropertyTest = function() {};
@@ -1214,7 +1219,7 @@ describe("lolex", function () {
         // TODO: The following tests causes test suite instability
 
         it("mirrors custom Date properties", function () {
-            var f = function () { };
+            var f = function () { return ""; };
             global.Date.format = f;
             this.clock = lolex.install();
 


### PR DESCRIPTION
`npm run lint` was failing. These seem to be the minimum changes required for it to be happy. I've tried fixing lint errors in the test file as well but there are two cases however that jslint won't ever be happy about. I've added a comment explaining to comment those out.

Perhaps a different linter should be used?

I've added linting (of the source file) to the CI script to ensure the source stays nice and tidy.