### PR TITLE
Update readme and some code description fixes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -125,7 +125,7 @@ It affects the current time but it does not in itself cause e.g. timers to fire;
 ## Running tests
 
 Lolex has a comprehensive test suite. If you're thinking of contributing bug
-fixes or suggest new features, you need to make sure you have not broken any
+fixes or suggesting new features, you need to make sure you have not broken any
 tests. You are also expected to add tests for any new behavior.
 
 ### On node:
@@ -134,15 +134,20 @@ tests. You are also expected to add tests for any new behavior.
 npm test
 ```
 
-Or, if you prefer slightly less verbose output:
+Or, if you prefer more verbose output:
 
 ```
-mocha ./test/lolex-test.js
+$(npm bin)/mocha ./test/lolex-test.js
 ```
 
 ### In the browser
 
+[Mochify](https://github.com/mantoni/mochify.js) is used to run the tests in
+PhantomJS. Make sure you have `phantomjs` installed. Then:
 
+```sh
+npm test-headless
+```
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -57,29 +57,40 @@ When using lolex to test timers, you will most likely want to replace the native
 timers such that calling `setTimeout` actually schedules a callback with your
 clock instance, not the browser's internals.
 
-To hijack timers in another context, use the `install` method. You can then call
-`uninstall` later to restore things as they were again.
+Calling `install` with no arguments achieves this. You can call `uninstall`
+later to restore things as they were again.
+
+```js
+// In the browser distribution, a global `lolex` is already available
+var lolex = require("lolex");
+
+var clock = lolex.install();
+// Equivalent to
+// var clock = lolex.install(typeof global !== "undefined" ? global : window);
+
+setTimeout(fn, 15); // Schedules with clock.setTimeout
+
+clock.uninstall();
+// setTimeout is restored to the native implementation
+```
+
+To hijack timers in another context pass it to the `install` method.
 
 ```js
 var lolex = require("lolex");
-var clock = lolex.install(window);
+var context = {
+    setTimeout: setTimeout // By default context.setTimeout uses the global setTimeout
+}
+var clock = lolex.install(context);
 
-window.setTimeout(fn, 15); // Schedules with clock.setTimeout
+context.setTimeout(fn, 15); // Schedules with clock.setTimeout
 
 clock.uninstall();
-
-// window.setTimeout is restored to the native implementation
+// context.setTimeout is restored to the original implementation
 ```
 
-In 90% av the times, you want to install the timers onto the global object.
-Calling `install` with no arguments achieves this:
-
-```js
-var clock = lolex.install();
-
-// Equivalent to
-// var clock = lolex.install(typeof global !== "undefined" ? global : window);
-```
+Usually you want to install the timers onto the global object, so call `install`
+without arguments.
 
 ## API Reference
 

--- a/Readme.md
+++ b/Readme.md
@@ -96,31 +96,93 @@ without arguments.
 
 ### `var clock = lolex.createClock([now])`
 
+Creates a clock. The default
+[epoch](https://en.wikipedia.org/wiki/Epoch_%28reference_date%29) is `0`. Now
+may be a number (in milliseconds) or a Date object.
+
 ### `var clock = lolex.install([context[, now[, toFake]]])`
 
 ### `var clock = lolex.install([now[, toFake]])`
 
+Creates a clock and installs it onto the `context` object, or globally. The
+`now` argument is the same as in `lolex.createClock()`.
+
+`toFake` is an array of the names of the methods that should be faked. You can
+pick from `setTimeout`, `clearTimeout`, `setImmediate`, `clearImmediate`,
+`setInterval`, `clearInterval`, and `Date`. E.g. `lolex.install(["setTimeout",
+"clearTimeout"])`.
+
 ### `var id = clock.setTimeout(callback, timeout)`
+
+Schedules the callback to be fired once `timeout` milliseconds have ticked by.
+
+In Node.js `setTimeout` returns a timer object. Lolex will do the same, however
+its `ref()` and `unref()` methods have no effect.
+
+In browsers a timer ID is returned.
 
 ### `clock.clearTimeout(id)`
 
+Clears the timer given the ID or timer object, as long as it was created using
+`setTimeout`.
+
 ### `var id = clock.setInterval(callback, timeout)`
+
+Schedules the callback to be fired every time `timeout` milliseconds have ticked
+by.
+
+In Node.js `setInterval` returns a timer object. Lolex will do the same, however
+its `ref()` and `unref()` methods have no effect.
+
+In browsers a timer ID is returned.
 
 ### `clock.clearInterval(id)`
 
+Clears the timer given the ID or timer object, as long as it was created using
+`setInterval`.
+
 ### `var id = clock.setImmediate(callback)`
+
+Schedules the callback, to be fired once `0` milliseconds have ticked by. Note
+that you'll still have to call `clock.tick()` for the callback to fire. If
+called during a tick the callback won't fire until `1` millisecond has ticked
+by.
+
+In Node.js `setImmediate` returns a timer object. Lolex will do the same,
+however its `ref()` and `unref()` methods have no effect.
+
+In browsers a timer ID is returned.
 
 ### `clock.clearImmediate(id)`
 
+Clears the timer given the ID or timer object, as long as it was created using
+`setImmediate`.
+
 ### `clock.tick(time)`
 
+Advance the clock, firing callbacks if necessary. `time` may be the number of
+milliseconds to advance the clock by or a human-readable string. Valid string
+formats are `"08"` for eight seconds, `"01:00"` for one minute and `"02:34:10"`
+for two hours, 34 minutes and ten seconds.
+
+`time` may be negative, which causes the clock to change but won't fire any
+callbacks.
+
 ### `clock.setSystemTime([now])`
+
 This simulates a user changing the system clock while your program is running.
-It affects the current time but it does not in itself cause e.g. timers to fire; they will fire exactly as they would have done without the call to setSystemTime().
+It affects the current time but it does not in itself cause e.g. timers to fire;
+they will fire exactly as they would have done without the call to
+setSystemTime().
 
 ### `clock.uninstall()`
 
+Restores the original methods on the `context` that was passed to
+`lolex.install`, or the native timers if no `context` was given.
+
 ### `Date`
+
+Implements the `Date` object but using the clock to provide the correct time.
 
 ## Running tests
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,9 @@
 # Lolex [![Build Status](https://secure.travis-ci.org/sinonjs/lolex.png)](http://travis-ci.org/sinonjs/lolex)
 
 JavaScript implementation of the timer APIs; `setTimeout`, `clearTimeout`,
-`setImmediate`, `clearImmediate`, `setInterval`, `clearInterval`, and
-`requestAnimationFrame`, along with a clock instance that controls the flow of
-time. Lolex also provides a `Date` implementation that gets its time from the
-clock.
+`setImmediate`, `clearImmediate`, `setInterval` and `clearInterval`, along with
+a clock instance that controls the flow of time. Lolex also provides a `Date`
+implementation that gets its time from the clock.
 
 Lolex can be used to simulate passing time in automated tests and other
 situations where you want the scheduling semantics, but don't want to actually

--- a/lolex.js
+++ b/lolex.js
@@ -56,7 +56,7 @@
         var ms = 0, parsed;
 
         if (l > 3 || !/^(\d\d:){0,2}\d\d?$/.test(str)) {
-            throw new Error("tick only understands numbers and 'h:m:s'");
+            throw new Error("tick only understands numbers, 'm:s' and 'h:m:s'. Each part must be two digits");
         }
 
         while (i--) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-node": "mocha -R dot",
     "test-headless": "mochify",
     "test-cloud": "mochify --wd",
-    "test": "npm run lint && npm run test-node && npm run test-headless && npm run test-cloud",
+    "test": "npm run lint && npm run test-node && npm run test-headless",
     "bundle": "browserify -s lolex -o lolex.js src/lolex.js"
   },
   "devDependencies": {

--- a/src/lolex.js
+++ b/src/lolex.js
@@ -54,7 +54,7 @@
         var ms = 0, parsed;
 
         if (l > 3 || !/^(\d\d:){0,2}\d\d?$/.test(str)) {
-            throw new Error("tick only understands numbers and 'h:m:s'");
+            throw new Error("tick only understands numbers, 'm:s' and 'h:m:s'. Each part must be two digits");
         }
 
         while (i--) {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -494,7 +494,7 @@ describe("lolex", function () {
             assert.equals(callback.callCount, 3);
         });
 
-        it("passes 6 seconds", function () {
+        it("passes 8 seconds", function () {
             var spy = sinon.spy();
             this.clock.setInterval(spy, 4000);
 
@@ -512,7 +512,7 @@ describe("lolex", function () {
             assert.equals(spy.callCount, 10);
         });
 
-        it("passes 2 hours, 34 minutes and 12 seconds", function () {
+        it("passes 2 hours, 34 minutes and 10 seconds", function () {
             var spy = sinon.spy();
             this.clock.setInterval(spy, 10000);
 


### PR DESCRIPTION
* `requestAnimationFrame` was mentioned but I don't see any code support for it. I've removed it from the docs, but please shout if I overlooked it.
* Updated the "Faking the native timers" section so it leads with the default behavior and better explains "context".
* Updated the "Running tests" section
* Added far more complete API docs, including allowed values for the various arguments.
* I've changed `npm test` to not run `test-cloud` since that requires Sauce Lab access.
* Fixed the `parseTime()` error message which mentioned fewer options than were allowed.
* Corrected some time related test descriptions where the description didn't match the time in the test itself.