### PR TITLE
Implement clock.next()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,9 @@ Upon executing the last line, an interesting fact about the
 the screen. If you want to simulate asynchronous behavior, you have to use your
 imagination when calling the various functions.
 
+The `next` method is available to advance to the next scheduled timer. See the
+API Reference for more.
+
 ### Faking the native timers
 
 When using lolex to test timers, you will most likely want to replace the native
@@ -103,6 +106,10 @@ var clock = lolex.install();
 ### `clock.clearImmediate(id)`
 
 ### `clock.tick(time)`
+
+### `clock.next()`
+
+Advances the clock to the the moment of the first scheduled timer, firing it.
 
 ### `clock.setSystemTime([now])`
 This simulates a user changing the system clock while your program is running.

--- a/lolex.js
+++ b/lolex.js
@@ -234,6 +234,22 @@
         return timer;
     }
 
+    function firstTimer(clock) {
+        var timers = clock.timers,
+            timer = null,
+            id;
+
+        for (id in timers) {
+            if (timers.hasOwnProperty(id)) {
+                if (!timer || compareTimers(timer, timers[id]) === 1) {
+                    timer = timers[id];
+                }
+            }
+        }
+
+        return timer;
+    }
+
     function callTimer(clock, timer) {
         var exception;
 
@@ -457,6 +473,22 @@
             }
 
             return clock.now;
+        };
+
+        clock.next = function next() {
+            var timer = firstTimer(clock);
+            if (!timer) {
+                return clock.now;
+            }
+
+            clock.duringTick = true;
+            try {
+                clock.now = timer.callAt;
+                callTimer(clock, timer);
+                return clock.now;
+            } finally {
+                clock.duringTick = false;
+            }
         };
 
         clock.reset = function reset() {

--- a/src/lolex.js
+++ b/src/lolex.js
@@ -232,6 +232,22 @@
         return timer;
     }
 
+    function firstTimer(clock) {
+        var timers = clock.timers,
+            timer = null,
+            id;
+
+        for (id in timers) {
+            if (timers.hasOwnProperty(id)) {
+                if (!timer || compareTimers(timer, timers[id]) === 1) {
+                    timer = timers[id];
+                }
+            }
+        }
+
+        return timer;
+    }
+
     function callTimer(clock, timer) {
         var exception;
 
@@ -455,6 +471,22 @@
             }
 
             return clock.now;
+        };
+
+        clock.next = function next() {
+            var timer = firstTimer(clock);
+            if (!timer) {
+                return clock.now;
+            }
+
+            clock.duringTick = true;
+            try {
+                clock.now = timer.callAt;
+                callTimer(clock, timer);
+                return clock.now;
+            } finally {
+                clock.duringTick = false;
+            }
         };
 
         clock.reset = function reset() {


### PR DESCRIPTION
Rather than ticking by a certain number of milliseconds this method advanced the clock to the first scheduled timer. This is useful when performing fuzz testing on an entire application and you want to trigger a single timer.

I based the tests off of those for `clock.tick()`.

Let me know what you think! :smile: 