### PR TITLE
Remove BASH syntax in lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "lint": "$(npm bin)/jslint src/**/*.js",
+    "lint": "jslint src/**/*.js",
     "test-node": "mocha -R dot",
     "test-headless": "mochify",
     "test-cloud": "mochify --wd",


### PR DESCRIPTION
Could not run `npm run lint` on Windows due to `$(..)` syntax.