### PR TITLE
Run test-cloud on Travis

### DIFF
--- a/.min-wd
+++ b/.min-wd
@@ -1,7 +1,7 @@
 {
   "sauceLabs": true,
   "browsers": [{
-    "name": "chrome"
+    "name": "firefox"
   }, {
     "name": "internet explorer",
     "version": "9",
@@ -9,5 +9,8 @@
   }, {
     "name": "internet explorer",
     "version": "10"
+  }, {
+    "name": "internet explorer",
+    "version": "11"
   }]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ node_js:
   - "0.12"
   - "4.2"
   - "5"
+
+env:
+  global:
+    - SAUCE_USERNAME=sinonjs
+    - secure: "Szc/biR+MJFC/r4IFzDVXJkIt1COglrCyCd/drmBrXj4AE70J2qn8QlU0n3uQUhrDH5k0NtSWnZHcfxuUTHpasvh9yPFGtqnNeqgftZjXQyJFS+rYye4i04cyYGEmc1qxhpljfAXbvCJV+bHDFmWxIF6KSHWMsVk6IbhoD0/Dis="
+
 script:
   - "./script/ci-test.sh"
+  - 'if [ "x$TRAVIS_NODE_VERSION" = "x4.2" ]; then npm run test-cloud; fi'
 


### PR DESCRIPTION
We already have the possibility to run tests in real browsers with `npm run test-cloud`. The prerequisite to be able to run this command is a free SauceLabs account and the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables.

If these environment variables are configured in the Travis config, SauceLabs can be used from there. With this config, we run the `test-cloud` build only once in the node 4.2 build.

I used my SauceLabs account for the purpose of trying this out. We can keep it this way or create a „Sinon“ account which we can share. The access key was encrypted using the method described [in the Travis documentation](https://docs.travis-ci.com/user/encryption-keys/).

The first successful build (from this branch) is here: https://travis-ci.org/sinonjs/lolex/jobs/112401049

For some unknown reason the Chrome build returns a status code 102 every single time. I have this running successfully in another project, but it doesn’t work reliably with Lolex. However, the build passes on latest Firefox and IE 9, 10 and 11.

We can add more browser configs of cause in the `.min-wd` file.

Any thoughts?