### PR TITLE
Add tests about Date creation

### DIFF
--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1062,6 +1062,20 @@ describe("lolex", function () {
             assert.equals(fakeDate.getTime(), date.getTime());
         });
 
+        it("creates regular date when passing a date as string", function () {
+            var date = new Date();
+            var fakeDate = new this.clock.Date(date.toISOString());
+
+            assert.equals(fakeDate.getTime(), date.getTime());
+        });
+
+        it("creates regular date when passing a date as RFC 2822 string", function () {
+            var date = new Date('Sat Apr 12 2014 12:22:00 GMT+1000');
+            var fakeDate = new this.clock.Date('Sat Apr 12 2014 12:22:00 GMT+1000');
+
+            assert.equals(fakeDate.getTime(), date.getTime());
+        });
+
         it("returns regular date when calling with timestamp", function () {
             var date = new Date();
             var fakeDate = this.clock.Date(date.getTime());


### PR DESCRIPTION
Add tests demonstrating that a fake Date could be created with one argument as a String since this string is in a format recognized by the Date.parse() method.