### PR TITLE
Check for existence of `process` before using it

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -405,8 +405,11 @@
         setInterval: setInterval,
         clearInterval: clearInterval,
         Date: Date,
-        hrtime: global.process.hrtime
     };
+
+    if (hrtimePresent) {
+        timers.hrtime = global.process.hrtime;
+    }
 
     var keys = Object.keys || function (obj) {
         var ks = [],


### PR DESCRIPTION
This fixes a bug where Lolex would no longer work in browsers because `process` doesn't exist.