### PR TITLE
Correct the clear{Interval|Timeout|Immediate} error message when attempting to clear a different type of timer.

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -343,7 +343,7 @@
             if (timerType(timer) === ttype) {
                 delete clock.timers[timerId];
             } else {
-                throw new Error("Cannot clear timer: timer created with set" + ttype + "() but cleared with clear" + timerType(timer) + "()");
+                throw new Error("Cannot clear timer: timer created with set" + timerType(timer) + "() but cleared with clear" + ttype + "()");
             }
         }
     }

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -243,6 +243,8 @@ describe("lolex", function () {
             var id = this.clock.setTimeout(callback, 50);
             assert.exception(function () {
                 this.clock.clearImmediate(id);
+            }.bind(this), {
+                message: "Cannot clear timer: timer created with setTimeout() but cleared with clearImmediate()"
             });
             this.clock.tick(55);
 
@@ -255,6 +257,8 @@ describe("lolex", function () {
             var id = this.clock.setInterval(callback, 50);
             assert.exception(function () {
                 this.clock.clearImmediate(id);
+            }.bind(this), {
+                message: "Cannot clear timer: timer created with setInterval() but cleared with clearImmediate()"
             });
             this.clock.tick(55);
 
@@ -998,6 +1002,8 @@ describe("lolex", function () {
             var id = this.clock.setInterval(stub, 50);
             assert.exception(function () {
                 this.clock.clearTimeout(id);
+            }.bind(this), {
+                message: "Cannot clear timer: timer created with setInterval() but cleared with clearTimeout()"
             });
             this.clock.tick(50);
 
@@ -1009,6 +1015,8 @@ describe("lolex", function () {
             var id = this.clock.setImmediate(stub);
             assert.exception(function () {
                 this.clock.clearTimeout(id);
+            }.bind(this), {
+                message: "Cannot clear timer: timer created with setImmediate() but cleared with clearTimeout()"
             });
             this.clock.tick(50);
 
@@ -1146,6 +1154,8 @@ describe("lolex", function () {
             var id = this.clock.setTimeout(stub, 50);
             assert.exception(function () {
                 this.clock.clearInterval(id);
+            }.bind(this), {
+                message: "Cannot clear timer: timer created with setTimeout() but cleared with clearInterval()"
             });
             this.clock.tick(50);
             assert.isTrue(stub.called);
@@ -1156,6 +1166,8 @@ describe("lolex", function () {
             var id = this.clock.setImmediate(stub);
             assert.exception(function () {
                 this.clock.clearInterval(id);
+            }.bind(this), {
+                message: "Cannot clear timer: timer created with setImmediate() but cleared with clearInterval()"
             });
             this.clock.tick(50);
 


### PR DESCRIPTION
The error message given when a timer created by `setTimeout` is cleared by a different type is wrong - the `set* / clear*` types are the wrong way around.

Additionally the test cases for the exceptions are currently not testing the code correctly - currently the error thrown is `Cannot read property 'clock' of undefined` due to the missing bind.

This fixes the error message and tests that its correct for all the combinations.