### PR TITLE
Fix setInterval() behavior with string times

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -173,7 +173,7 @@
 
         timer.id = uniqueTimerId++;
         timer.createdAt = clock.now;
-        timer.callAt = clock.now + (timer.delay || (clock.duringTick ? 1 : 0));
+        timer.callAt = clock.now + (parseInt(timer.delay) || (clock.duringTick ? 1 : 0));
 
         clock.timers[timer.id] = timer;
 

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -90,6 +90,20 @@ describe("lolex", function () {
             assert(stubs[1].called);
         });
 
+        it("parses numeric string times", function () {
+            this.clock.setTimeout(function () { lolex.evalCalled = true; }, "10");
+            this.clock.tick(10);
+
+            assert(lolex.evalCalled);
+        });
+
+        it("parses no-numeric string times", function () {
+            this.clock.setTimeout(function () { lolex.evalCalled = true; }, "string");
+            this.clock.tick(10);
+
+            assert(lolex.evalCalled);
+        });
+
         it("evals non-function callbacks", function () {
             this.clock.setTimeout("lolex.evalCalled = true", 10);
             this.clock.tick(10);


### PR DESCRIPTION
In Node.js, when setTimeout is called with an time string, it is parsed. If the string is an invalid number, it's assumed as 0. In lolex, using a string as time causes the setTimeout not to trigger the callback function.

This is the behaviour that I would expect:

```js
it("parses no-numeric string times", function () {
    this.clock.setTimeout(function () { lolex.evalCalled = true; }, "string");
    this.clock.tick(10);

    assert(lolex.evalCalled);
});

it("evals non-function callbacks", function () {
    this.clock.setTimeout("lolex.evalCalled = true", 10);
    this.clock.tick(10);

    assert(lolex.evalCalled);
});
```