### PR TITLE
Fix sinonjs/sinon#1143: Only overwrite globals when running in IE

### DIFF
--- a/lolex.js
+++ b/lolex.js
@@ -175,7 +175,7 @@
 
         timer.id = uniqueTimerId++;
         timer.createdAt = clock.now;
-        timer.callAt = clock.now + (timer.delay || (clock.duringTick ? 1 : 0));
+        timer.callAt = clock.now + (parseInt(timer.delay) || (clock.duringTick ? 1 : 0));
 
         clock.timers[timer.id] = timer;
 

--- a/lolex.js
+++ b/lolex.js
@@ -1,13 +1,5 @@
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.lolex = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 (function (global){
-/*global global, window*/
-/**
- * @author Christian Johansen (christian@cjohansen.no) and contributors
- * @license BSD
- *
- * Copyright (c) 2010-2014 Christian Johansen
- */
-
 (function (global) {
     "use strict";
 

--- a/lolex.js
+++ b/lolex.js
@@ -3,13 +3,18 @@
 (function (global) {
     "use strict";
 
+    var userAgent = global.navigator && global.navigator.userAgent;
+    var isRunningInIE = userAgent && userAgent.indexOf("MSIE ") > -1;
+
     // Make properties writable in IE, as per
     // http://www.adequatelygood.com/Replacing-setTimeout-Globally.html
-    global.setTimeout = global.setTimeout;
-    global.clearTimeout = global.clearTimeout;
-    global.setInterval = global.setInterval;
-    global.clearInterval = global.clearInterval;
-    global.Date = global.Date;
+    if (isRunningInIE) {
+        global.setTimeout = global.setTimeout;
+        global.clearTimeout = global.clearTimeout;
+        global.setInterval = global.setInterval;
+        global.clearInterval = global.clearInterval;
+        global.Date = global.Date;
+    }
 
     // setImmediate is not a standard function
     // avoid adding the prop to the window object if not present

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "prepublish": "npm run bundle"
   },
   "devDependencies": {
-    "eslint": "^3.0.1",
     "browserify": "^13.0.1",
-    "mocha": "^2.5.3",
+    "eslint": "^3.0.1",
+    "mocha": "^3.1.2",
     "mochify": "^2.18.0",
     "referee": "^1.2.0",
     "sinon": "^1.17.4"

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -1,13 +1,18 @@
 (function (global) {
     "use strict";
 
+    var userAgent = global.navigator && global.navigator.userAgent;
+    var isRunningInIE = userAgent && userAgent.indexOf("MSIE ") > -1;
+
     // Make properties writable in IE, as per
     // http://www.adequatelygood.com/Replacing-setTimeout-Globally.html
-    global.setTimeout = global.setTimeout;
-    global.clearTimeout = global.clearTimeout;
-    global.setInterval = global.setInterval;
-    global.clearInterval = global.clearInterval;
-    global.Date = global.Date;
+    if (isRunningInIE) {
+        global.setTimeout = global.setTimeout;
+        global.clearTimeout = global.clearTimeout;
+        global.setInterval = global.setInterval;
+        global.clearInterval = global.clearInterval;
+        global.Date = global.Date;
+    }
 
     // setImmediate is not a standard function
     // avoid adding the prop to the window object if not present

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -1,11 +1,3 @@
-/*global global, window*/
-/**
- * @author Christian Johansen (christian@cjohansen.no) and contributors
- * @license BSD
- *
- * Copyright (c) 2010-2014 Christian Johansen
- */
-
 (function (global) {
     "use strict";
 


### PR DESCRIPTION
This is a PR for **master**, it is a solution for https://github.com/sinonjs/sinon/issues/1143

The PR fixes compatibility with React Native and quite possibly other libraries.

#### To verify bug

1. Run test in https://github.com/mroderick/sinon-issue-1143
1. Observe that an error occurs

```
TypeError: Date is not a constructor

  at new MessageQueue (node_modules/react-native/Libraries/Utilities/MessageQueue.js:62:26)
  at Object.<anonymous> (node_modules/react-native/Libraries/BatchedBridge/BatchedBridge.js:17:19)
  at Object.<anonymous> (node_modules/react-native/Libraries/Utilities/RCTLog.js:14:19)
  at setUpConsole (node_modules/react-native/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js:54:1)
```

#### To verify solution

1. Check out this PR, switch into that folder
1. `npm link`
1. Switch back to your `sinon-issue-1143` folder that you just used above
1. `cd node_modules/sinon/`
1. `npm link lolex`
1. `cd -`
1. `npm test`
1. Observe that test test passes