### PR TITLE
Fixed typo in clock.runAll error

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -551,7 +551,7 @@
                 clock.next();
             }
 
-            throw new Error("Aborting after running " + clock.loopLimit + "timers, assuming an infinite loop!");
+            throw new Error("Aborting after running " + clock.loopLimit + " timers, assuming an infinite loop!");
         };
 
         clock.runToLast = function runToLast() {


### PR DESCRIPTION
Error would previously say `"Aborting after running 1000timers, assuming an infinite loop!"` (notice the lack of space between `1000` and `timers`). Adding a space there.

Fixes #93.