### PR TITLE
Run tests in node 4, 6, 8 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: node_js
 sudo: false
 
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4.2"
-  - "5"
+  # https://github.com/nodejs/LTS
+  - "4" # ends April 2018
+  - "6" # ends April 2019
+  - "8" # ends December 2019
 
 env:
   global:


### PR DESCRIPTION
This PR configures Travis CI to use node 4, 6 and 8 (LTS versions)