### PR TITLE
lolex can now attach itself to the system timers and automatically ad…

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,8 @@ v2.0.0 / 2017-07-13
   * Add support for performance.now (#106)
   * Fix issue with tick(): setSystemClock then throw
   * Update old dependencies
+  * Added support to automatically increment time (#85)
+  * Changed internal uninstall method signature
 
 v1.6.0 / 2017-02-25
 ===================

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,9 @@ implementation that gets its time from the clock.
 
 Lolex can be used to simulate passing time in automated tests and other
 situations where you want the scheduling semantics, but don't want to actually
-wait. Lolex is extracted from [Sinon.JS](https://github.com/sinonjs/sinon.js).
+wait (however, from version 2.0 lolex supports those of you who would like to wait too). 
+
+Lolex is extracted from [Sinon.JS](https://github.com/sinonjs/sinon.js).
 
 ## Installation
 
@@ -80,7 +82,7 @@ var lolex = require("lolex");
 var context = {
     setTimeout: setTimeout // By default context.setTimeout uses the global setTimeout
 }
-var clock = lolex.install(context);
+var clock = lolex.install({target: context});
 
 context.setTimeout(fn, 15); // Schedules with clock.setTimeout
 
@@ -90,6 +92,35 @@ clock.uninstall();
 
 Usually you want to install the timers onto the global object, so call `install`
 without arguments.
+
+#### Automatically incrementing mocked time
+Since version 2.0 Lolex supports the possibility to attach the faked timers
+to any change in the real system time. This basically means you no longer need
+to `tick()` the clock in a situation where you won't know **when** to call `tick()`.
+
+Please note that this is achieved using the original setImmediate() API at a certain
+configurable interval `config.advanceTimeDelta` (default: 20ms). Meaning time would
+be incremented every 20ms, not in real time. 
+
+An example would be:
+
+```js
+var lolex = require("lolex");
+var clock = lolex.install({shouldAdvanceTime: true, advanceTimeDelta: 40});
+
+setTimeout(() => {
+    console.log('this just timed out'); //executed after 40ms
+}, 30);
+
+setImmediate(() => {
+    console.log('not so immediate'); //executed after 40ms
+});
+
+setTimeout(() => {
+    console.log('this timed out after'); //executed after 80ms
+    clock.uninstall();
+}, 50);
+```
 
 ## API Reference
 
@@ -102,19 +133,17 @@ The `now` argument may be a number (in milliseconds) or a Date object.
 
 The `loopLimit` argument sets the maximum number of timers that will be run when calling `runAll()` before assuming that we have an infinite loop and throwing an error. The default is `1000`.
 
-### `var clock = lolex.install([context[, now[, toFake[, loopLimit]]]])`
+### `var clock = lolex.install([config])`
+Installs lolex using the specified config (otherwise with epoch `0` on the global scope). The following configuration options are available
 
-### `var clock = lolex.install([now[, toFake[, loopLimit]]])`
-
-Creates a clock and installs it onto the `context` object, or globally. The
-`now` argument is the same as in `lolex.createClock()`.
-
-`toFake` is an array of the names of the methods that should be faked. You can
-pick from `setTimeout`, `clearTimeout`, `setImmediate`, `clearImmediate`,
-`setInterval`, `clearInterval`, and `Date`. E.g. `lolex.install(["setTimeout",
-"clearTimeout"])`.
-
-The `loopLimit` argument is the same as in `lolex.createClock()`.
+Parameter | Type | Default | Description
+--------- | ---- | ------- | ------------
+`config.target`| Object | global | installs lolex onto the specified target context 
+`config.now` | Number/Date | 0 | installs lolex with the specified unix epoch 
+`config.toFake` | String[] | [] | an array with explicit function names to hijack. You can pick from `setTimeout`, `clearTimeout`, `setImmediate`, `clearImmediate`,`setInterval`, `clearInterval`, and `Date`. E.g. `lolex.install({ toFake: ["setTimeout","clearTimeout"]})`
+`config.loopLimit` | Number | 1000 | the maximum number of timers that will be run when calling runAll()
+`config.shouldAdvanceTime` | Boolean | false | tells lolex to increment mocked time automatically based on the real system time shift (e.g. the mocked time will be incremented by 20ms for every 20ms change in the real system time)
+`config.advanceTimeDelta` | Number | 20 | relevant only when using with `shouldAdvanceTime: true`. increment mocked time by `advanceTimeDelta` ms every `advanceTimeDelta` ms change in the real system time.
 
 ### `var id = clock.setTimeout(callback, timeout)`
 
@@ -179,7 +208,7 @@ for two hours, 34 minutes and ten seconds.
 `time` may be negative, which causes the clock to change but won't fire any
 callbacks.
 
-### `clock.next()`
+`clock.next()`
 
 Advances the clock to the the moment of the first scheduled timer, firing it.
 
@@ -211,8 +240,8 @@ setSystemTime().
 
 ### `clock.uninstall()`
 
-Restores the original methods on the `context` that was passed to
-`lolex.install`, or the native timers if no `context` was given.
+Restores the original methods on the `target` that was passed to
+`lolex.install`, or the native timers if no `target` was given.
 
 ### `Date`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lolex",
   "description": "Fake JavaScript timers",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "homepage": "http://github.com/sinonjs/lolex",
   "author": "Christian Johansen",
   "repository": {

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -400,8 +400,6 @@ function hijackMethod(target, method, clock) {
     target[method].clock = clock;
 }
 
-exports.shouldAdvanceTime = false;
-
 function doIntervalTick(clock, advanceTimeDelta) {
     clock.tick(advanceTimeDelta);
 }

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -35,6 +35,7 @@ clearTimeout(timeoutResult);
 var NativeDate = Date;
 var uniqueTimerId = 1;
 
+var TIME_TICK = 20; // increment the mocked timer on this real interval (ms)
 /**
  * Parse strings like "01:10:00" (meaning 1 hour, 10 minutes, 0 seconds) into
  * number of milliseconds. This is used to support human-readable strings passed
@@ -361,6 +362,9 @@ function uninstall(clock, target) {
         } else {
             if (target[method] && target[method].hadOwnProperty) {
                 target[method] = clock["_" + method];
+                if (method === "clearInterval" && exports.shouldAdvanceTime === true) {
+                    target[method](clock.attachedInterval);
+                }
             } else {
                 try {
                     delete target[method];
@@ -395,6 +399,12 @@ function hijackMethod(target, method, clock) {
     }
 
     target[method].clock = clock;
+}
+
+exports.shouldAdvanceTime = false;
+
+function doIntervalTick(clock) {
+    clock.tick(TIME_TICK);
 }
 
 var timers = {
@@ -659,6 +669,13 @@ exports.install = function install(config) {
                 hijackMethod(target.process, clock.methods[i], clock);
             }
         } else {
+            if (clock.methods[i] === "setInterval" && exports.shouldAdvanceTime === true) {
+                var intervalTick = doIntervalTick.bind(null, clock);
+                var intervalId = target[clock.methods[i]](
+                    intervalTick,
+                    TIME_TICK);
+                clock.attachedInterval = intervalId;
+            }
             hijackMethod(target, clock.methods[i], clock);
         }
     }

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1683,7 +1683,6 @@ describe("lolex", function () {
         }
         if (performancePresent) {
             it("replaces global performance.now", function () {
-
                 this.clock = lolex.install();
                 var prev = performance.now();
                 this.clock.tick(1000);

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1803,6 +1803,57 @@ describe("lolex", function () {
         });
     });
 
+    describe("shouldAdvanceTime", function () {
+        it("should create an auto advancing timer", function (done) {
+            var testDelay = 29;
+            var date = new Date("2015-09-25");
+            var clock = lolex.install({now: date, shouldAdvanceTime: true});
+            assert.same(Date.now(), 1443139200000);
+            var timeoutStarted = Date.now();
+
+            setTimeout(function () {
+                var timeDifference = Date.now() - timeoutStarted;
+                assert.same(timeDifference, testDelay);
+                clock.uninstall();
+                done();
+            }, testDelay);
+        });
+
+        it("should test setImmediate", function (done) {
+            var date = new Date("2015-09-25");
+            var clock = lolex.install({now: date, shouldAdvanceTime: true});
+            assert.same(Date.now(), 1443139200000);
+            var timeoutStarted = Date.now();
+
+            setImmediate(function () {
+                var timeDifference = Date.now() - timeoutStarted;
+                assert.same(timeDifference, 0);
+                clock.uninstall();
+                done();
+            });
+        });
+
+        it("should test setInterval", function (done) {
+            var interval = 20;
+            var intervalsTriggered = 0;
+            var cyclesToTrigger = 3;
+            var date = new Date("2015-09-25");
+            var clock = lolex.install({now: date, shouldAdvanceTime: true});
+            assert.same(Date.now(), 1443139200000);
+            var timeoutStarted = Date.now();
+
+            var intervalId = setInterval(function () {
+                if (++intervalsTriggered === cyclesToTrigger) {
+                    clearInterval(intervalId);
+                    var timeDifference = Date.now() - timeoutStarted;
+                    assert.same(timeDifference, interval * cyclesToTrigger);
+                    clock.uninstall();
+                    done();
+                }
+            }, interval);
+        });
+    });
+
     if (performancePresent) {
         describe("performance.now()", function () {
             it("should start at 0", function () {


### PR DESCRIPTION
in regards to issue #85: these changes will allow lolex to attach itself to the system timers when the clock is being installed.

when installing - lolex will set up a normal 'setInterval' on the real system timer (the one that's being stored at _setInterval) at a default value of 20ms, since every time the interval gets triggered the event loop will get blocked - I thought that 50hz is about enough to get good resolution but also not to clog the event loop at the same time (0.5-1 second is too much IMHO, 1ms too fast). every time the setInterval gets triggered - it will tick(20) thus resulting in timers getting invoked.

when uninstalling - lolex will remove the setInterval that was created.

i implemented the possibility to toggle this feature on and off through **exports.shouldAdvanceTime** - since I'm not sure that adding another argument to the constructor would be a wise choice for this use case - too much magic reordering arguments at the ctor and I would like to propagate this into sinon (which uses **install(now || 0, methods)**).
