### PR TITLE
Fix issue with tick(): setSystemClock then throw

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -495,14 +495,15 @@ function createClock(now, loopLimit) {
                 try {
                     oldNow = clock.now;
                     callTimer(clock, timer);
-                    // compensate for any setSystemTime() call during timer callback
-                    if (oldNow !== clock.now) {
-                        tickFrom += clock.now - oldNow;
-                        tickTo += clock.now - oldNow;
-                        previous += clock.now - oldNow;
-                    }
                 } catch (e) {
                     firstException = firstException || e;
+                }
+
+                // compensate for any setSystemTime() call during timer callback
+                if (oldNow !== clock.now) {
+                    tickFrom += clock.now - oldNow;
+                    tickTo += clock.now - oldNow;
+                    previous += clock.now - oldNow;
                 }
             }
 

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -637,6 +637,69 @@ describe("lolex", function () {
             var value = clock.tick(200);
             assert.equals(clock.now, value);
         });
+
+        it("is not influenced by forward system clock changes", function () {
+            var clock = this.clock;
+            var callback = function () {
+                clock.setSystemTime((new clock.Date()).getTime() + 1000);
+            };
+            var stub = sinon.stub();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            clock.tick(1990);
+            assert.equals(stub.callCount, 0);
+            clock.tick(20);
+            assert.equals(stub.callCount, 1);
+        });
+
+        it("is not influenced by forward system clock changes", function () {
+            var clock = this.clock;
+            var callback = function () {
+                clock.setSystemTime((new clock.Date()).getTime() - 1000);
+            };
+            var stub = sinon.stub();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            clock.tick(1990);
+            assert.equals(stub.callCount, 0);
+            clock.tick(20);
+            assert.equals(stub.callCount, 1);
+        });
+
+        it("is not influenced by forward system clock changes when an error is thrown", function () {
+            var clock = this.clock;
+            var callback = function () {
+                clock.setSystemTime((new clock.Date()).getTime() + 1000);
+                throw new Error();
+            };
+            var stub = sinon.stub();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            assert.exception(function () {
+                clock.tick(1990);
+            });
+            assert.equals(stub.callCount, 0);
+            clock.tick(20);
+            assert.equals(stub.callCount, 1);
+        });
+
+        it("is not influenced by forward system clock changes when an error is thrown", function () {
+            var clock = this.clock;
+            var callback = function () {
+                clock.setSystemTime((new clock.Date()).getTime() - 1000);
+                throw new Error();
+            };
+            var stub = sinon.stub();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            assert.exception(function () {
+                clock.tick(1990);
+            });
+            assert.equals(stub.callCount, 0);
+            clock.tick(20);
+            assert.equals(stub.callCount, 1);
+        });
+
     });
 
     describe("next", function () {


### PR DESCRIPTION
There is an issue with `tick()` when `setSystemClock` is called in a timer, and then that same timer throws an error. The correction that `tick()` does to account for `setSystemClock` happens within the try catch block, and not after it. If an error is thrown then this check is skipped.

The included unit tests demonstrate the issue.