### PR TITLE
Upgrade lolex with async versions of all timer-executing calls

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -495,14 +495,15 @@ function createClock(now, loopLimit) {
                 try {
                     oldNow = clock.now;
                     callTimer(clock, timer);
-                    // compensate for any setSystemTime() call during timer callback
-                    if (oldNow !== clock.now) {
-                        tickFrom += clock.now - oldNow;
-                        tickTo += clock.now - oldNow;
-                        previous += clock.now - oldNow;
-                    }
                 } catch (e) {
                     firstException = firstException || e;
+                }
+
+                // compensate for any setSystemTime() call during timer callback
+                if (oldNow !== clock.now) {
+                    tickFrom += clock.now - oldNow;
+                    tickTo += clock.now - oldNow;
+                    previous += clock.now - oldNow;
                 }
             }
 

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -637,6 +637,69 @@ describe("lolex", function () {
             var value = clock.tick(200);
             assert.equals(clock.now, value);
         });
+
+        it("is not influenced by forward system clock changes", function () {
+            var clock = this.clock;
+            var callback = function () {
+                clock.setSystemTime((new clock.Date()).getTime() + 1000);
+            };
+            var stub = sinon.stub();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            clock.tick(1990);
+            assert.equals(stub.callCount, 0);
+            clock.tick(20);
+            assert.equals(stub.callCount, 1);
+        });
+
+        it("is not influenced by forward system clock changes", function () {
+            var clock = this.clock;
+            var callback = function () {
+                clock.setSystemTime((new clock.Date()).getTime() - 1000);
+            };
+            var stub = sinon.stub();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            clock.tick(1990);
+            assert.equals(stub.callCount, 0);
+            clock.tick(20);
+            assert.equals(stub.callCount, 1);
+        });
+
+        it("is not influenced by forward system clock changes when an error is thrown", function () {
+            var clock = this.clock;
+            var callback = function () {
+                clock.setSystemTime((new clock.Date()).getTime() + 1000);
+                throw new Error();
+            };
+            var stub = sinon.stub();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            assert.exception(function () {
+                clock.tick(1990);
+            });
+            assert.equals(stub.callCount, 0);
+            clock.tick(20);
+            assert.equals(stub.callCount, 1);
+        });
+
+        it("is not influenced by forward system clock changes when an error is thrown", function () {
+            var clock = this.clock;
+            var callback = function () {
+                clock.setSystemTime((new clock.Date()).getTime() - 1000);
+                throw new Error();
+            };
+            var stub = sinon.stub();
+            clock.setTimeout(callback, 1000);
+            clock.setTimeout(stub, 2000);
+            assert.exception(function () {
+                clock.tick(1990);
+            });
+            assert.equals(stub.callCount, 0);
+            clock.tick(20);
+            assert.equals(stub.callCount, 1);
+        });
+
     });
 
     describe("next", function () {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -702,6 +702,695 @@ describe("lolex", function () {
 
     });
 
+    if (typeof global.Promise !== "undefined") {
+        describe("tickAsync", function () {
+
+            beforeEach(function () {
+                this.clock = lolex.install(0);
+            });
+
+            afterEach(function () {
+                this.clock.uninstall();
+            });
+
+            it("triggers immediately without specified delay", function () {
+                var stub = sinon.stub();
+                this.clock.setTimeout(stub);
+
+                return this.clock.tickAsync(0)
+                    .then(function () {
+                        assert(stub.called);
+                    });
+            });
+
+            it("does not trigger without sufficient delay", function () {
+                var stub = sinon.stub();
+                this.clock.setTimeout(stub, 100);
+
+                return this.clock.tickAsync(10)
+                    .then(function () {
+                        assert.isFalse(stub.called);
+                    });
+            });
+
+            it("triggers after sufficient delay", function () {
+                var stub = sinon.stub();
+                this.clock.setTimeout(stub, 100);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(stub.called);
+                    });
+            });
+
+            it("triggers simultaneous timers", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setTimeout(spies[0], 100);
+                this.clock.setTimeout(spies[1], 100);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert(spies[1].called);
+                    });
+            });
+
+            it("triggers multiple simultaneous timers", function () {
+                var spies = [sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()];
+                this.clock.setTimeout(spies[0], 100);
+                this.clock.setTimeout(spies[1], 100);
+                this.clock.setTimeout(spies[2], 99);
+                this.clock.setTimeout(spies[3], 100);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert(spies[1].called);
+                        assert(spies[2].called);
+                        assert(spies[3].called);
+                    });
+            });
+
+            it("triggers multiple simultaneous timers with zero callAt", function () {
+                var test = this;
+                var spies = [
+                    sinon.spy(function () {
+                        test.clock.setTimeout(spies[1], 0);
+                    }),
+                    sinon.spy(),
+                    sinon.spy()
+                ];
+
+                // First spy calls another setTimeout with delay=0
+                this.clock.setTimeout(spies[0], 0);
+                this.clock.setTimeout(spies[2], 10);
+
+                return this.clock.tickAsync(10)
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert(spies[1].called);
+                        assert(spies[2].called);
+                    });
+            });
+
+            it("triggers multiple simultaneous timers with zero callAt created in promises", function () {
+                var test = this;
+                var spies = [
+                    sinon.spy(function () {
+                        global.Promise.resolve().then(function () {
+                            test.clock.setTimeout(spies[1], 0);
+                        });
+                    }),
+                    sinon.spy(),
+                    sinon.spy()
+                ];
+
+                // First spy calls another setTimeout with delay=0
+                this.clock.setTimeout(spies[0], 0);
+                this.clock.setTimeout(spies[2], 10);
+
+                return this.clock.tickAsync(10)
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert(spies[1].called);
+                        assert(spies[2].called);
+                    });
+            });
+
+            it("waits after setTimeout was called", function () {
+                var clock = this.clock;
+                var stub = sinon.stub();
+
+                return clock.tickAsync(100)
+                    .then(function () {
+                        clock.setTimeout(stub, 150);
+                        return clock.tickAsync(50);
+                    }).then(function () {
+                        assert.isFalse(stub.called);
+                        return clock.tickAsync(100);
+                    }).then(function () {
+                        assert(stub.called);
+                    });
+            });
+
+            it("mini integration test", function () {
+                var clock = this.clock;
+                var stubs = [sinon.stub(), sinon.stub(), sinon.stub()];
+                clock.setTimeout(stubs[0], 100);
+                clock.setTimeout(stubs[1], 120);
+
+                return clock.tickAsync(10)
+                    .then(function () {
+                        return clock.tickAsync(89);
+                    }).then(function () {
+                        assert.isFalse(stubs[0].called);
+                        assert.isFalse(stubs[1].called);
+                        clock.setTimeout(stubs[2], 20);
+                        return clock.tickAsync(1);
+                    }).then(function () {
+                        assert(stubs[0].called);
+                        assert.isFalse(stubs[1].called);
+                        assert.isFalse(stubs[2].called);
+                        return clock.tickAsync(19);
+                    }).then(function () {
+                        assert.isFalse(stubs[1].called);
+                        assert(stubs[2].called);
+                        return clock.tickAsync(1);
+                    }).then(function () {
+                        assert(stubs[1].called);
+                    });
+            });
+
+            it("triggers even when some throw", function () {
+                var clock = this.clock;
+                var stubs = [sinon.stub().throws(), sinon.stub()];
+                var catchSpy = sinon.spy();
+
+                clock.setTimeout(stubs[0], 100);
+                clock.setTimeout(stubs[1], 120);
+
+                return clock.tickAsync(120)
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+                        assert(stubs[0].called);
+                        assert(stubs[1].called);
+                    });
+            });
+
+            it("calls function with global object or null (strict mode) as this", function () {
+                var clock = this.clock;
+                var stub = sinon.stub().throws();
+                var catchSpy = sinon.spy();
+                clock.setTimeout(stub, 100);
+
+                return clock.tickAsync(100)
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+                        assert(stub.calledOn(global) || stub.calledOn(null));
+                    });
+            });
+
+            it("triggers in the order scheduled", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setTimeout(spies[0], 13);
+                this.clock.setTimeout(spies[1], 11);
+
+                return this.clock.tickAsync(15)
+                    .then(function () {
+                        assert(spies[1].calledBefore(spies[0]));
+                    });
+            });
+
+            it("creates updated Date while ticking", function () {
+                var spy = sinon.spy();
+
+                this.clock.setInterval(function () {
+                    spy(new Date().getTime());
+                }, 10);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert.equals(spy.callCount, 10);
+                        assert(spy.calledWith(10));
+                        assert(spy.calledWith(20));
+                        assert(spy.calledWith(30));
+                        assert(spy.calledWith(40));
+                        assert(spy.calledWith(50));
+                        assert(spy.calledWith(60));
+                        assert(spy.calledWith(70));
+                        assert(spy.calledWith(80));
+                        assert(spy.calledWith(90));
+                        assert(spy.calledWith(100));
+                    });
+            });
+
+            it("creates updated Date while ticking promises", function () {
+                var spy = sinon.spy();
+
+                this.clock.setInterval(function () {
+                    global.Promise.resolve().then(function () {
+                        spy(new Date().getTime());
+                    });
+                }, 10);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert.equals(spy.callCount, 10);
+                        assert(spy.calledWith(10));
+                        assert(spy.calledWith(20));
+                        assert(spy.calledWith(30));
+                        assert(spy.calledWith(40));
+                        assert(spy.calledWith(50));
+                        assert(spy.calledWith(60));
+                        assert(spy.calledWith(70));
+                        assert(spy.calledWith(80));
+                        assert(spy.calledWith(90));
+                        assert(spy.calledWith(100));
+                    });
+            });
+
+            it("fires timer in intervals of 13", function () {
+                var spy = sinon.spy();
+                this.clock.setInterval(spy, 13);
+
+                return this.clock.tickAsync(500)
+                    .then(function () {
+                        assert.equals(spy.callCount, 38);
+                    });
+            });
+
+            it("fires timers in correct order", function () {
+                var spy13 = sinon.spy();
+                var spy10 = sinon.spy();
+
+                this.clock.setInterval(function () {
+                    spy13(new Date().getTime());
+                }, 13);
+
+                this.clock.setInterval(function () {
+                    spy10(new Date().getTime());
+                }, 10);
+
+                return this.clock.tickAsync(500)
+                    .then(function () {
+                        assert.equals(spy13.callCount, 38);
+                        assert.equals(spy10.callCount, 50);
+
+                        assert(spy13.calledWith(416));
+                        assert(spy10.calledWith(320));
+
+                        assert(spy10.getCall(0).calledBefore(spy13.getCall(0)));
+                        assert(spy10.getCall(4).calledBefore(spy13.getCall(3)));
+                    });
+            });
+
+            it("fires promise timers in correct order", function () {
+                var spy13 = sinon.spy();
+                var spy10 = sinon.spy();
+
+                this.clock.setInterval(function () {
+                    global.Promise.resolve().then(function () {
+                        spy13(new Date().getTime());
+                    });
+                }, 13);
+
+                this.clock.setInterval(function () {
+                    global.Promise.resolve().then(function () {
+                        spy10(new Date().getTime());
+                    });
+                }, 10);
+
+                return this.clock.tickAsync(500)
+                    .then(function () {
+                        assert.equals(spy13.callCount, 38);
+                        assert.equals(spy10.callCount, 50);
+
+                        assert(spy13.calledWith(416));
+                        assert(spy10.calledWith(320));
+
+                        assert(spy10.getCall(0).calledBefore(spy13.getCall(0)));
+                        assert(spy10.getCall(4).calledBefore(spy13.getCall(3)));
+                    });
+            });
+
+            it("triggers timeouts and intervals in the order scheduled", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setInterval(spies[0], 10);
+                this.clock.setTimeout(spies[1], 50);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(spies[0].calledBefore(spies[1]));
+                        assert.equals(spies[0].callCount, 10);
+                        assert.equals(spies[1].callCount, 1);
+                    });
+            });
+
+            it("does not fire canceled intervals", function () {
+                var id;
+                var callback = sinon.spy(function () {
+                    if (callback.callCount === 3) {
+                        clearInterval(id);
+                    }
+                });
+
+                id = this.clock.setInterval(callback, 10);
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert.equals(callback.callCount, 3);
+                    });
+            });
+
+            it("does not fire intervals canceled in a promise", function () {
+                var id;
+                var callback = sinon.spy(function () {
+                    if (callback.callCount === 3) {
+                        global.Promise.resolve().then(function () {
+                            clearInterval(id);
+                        });
+                    }
+                });
+
+                id = this.clock.setInterval(callback, 10);
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert.equals(callback.callCount, 3);
+                    });
+            });
+
+            it("passes 8 seconds", function () {
+                var spy = sinon.spy();
+                this.clock.setInterval(spy, 4000);
+
+                return this.clock.tickAsync("08")
+                    .then(function () {
+                        assert.equals(spy.callCount, 2);
+                    });
+            });
+
+            it("passes 1 minute", function () {
+                var spy = sinon.spy();
+                this.clock.setInterval(spy, 6000);
+
+                return this.clock.tickAsync("01:00")
+                    .then(function () {
+                        assert.equals(spy.callCount, 10);
+                    });
+            });
+
+            it("passes 2 hours, 34 minutes and 10 seconds", function () {
+                var spy = sinon.spy();
+                this.clock.setInterval(spy, 10000);
+
+                return this.clock.tickAsync("02:34:10")
+                    .then(function () {
+                        assert.equals(spy.callCount, 925);
+                    });
+            });
+
+            it("throws for invalid format", function () {
+                var spy = sinon.spy();
+                this.clock.setInterval(spy, 10000);
+                var test = this;
+                var catchSpy = sinon.spy();
+
+                return test.clock.tickAsync("12:02:34:10")
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+                        assert.equals(spy.callCount, 0);
+                    });
+            });
+
+            it("throws for invalid minutes", function () {
+                var spy = sinon.spy();
+                this.clock.setInterval(spy, 10000);
+                var test = this;
+                var catchSpy = sinon.spy();
+
+                return test.clock.tickAsync("67:10")
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+                        assert.equals(spy.callCount, 0);
+                    });
+            });
+
+            it("throws for negative minutes", function () {
+                var spy = sinon.spy();
+                this.clock.setInterval(spy, 10000);
+                var test = this;
+                var catchSpy = sinon.spy();
+
+                return test.clock.tickAsync("-7:10")
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+                        assert.equals(spy.callCount, 0);
+                    });
+            });
+
+            it("treats missing argument as 0", function () {
+                var clock = this.clock;
+                return this.clock.tickAsync()
+                    .then(function () {
+                        assert.equals(clock.now, 0);
+                    });
+            });
+
+            it("fires nested setTimeout calls properly", function () {
+                var i = 0;
+                var clock = this.clock;
+
+                var callback = function () {
+                    ++i;
+                    clock.setTimeout(function () {
+                        callback();
+                    }, 100);
+                };
+
+                callback();
+
+                return clock.tickAsync(1000)
+                    .then(function () {
+                        assert.equals(i, 11);
+                    });
+            });
+
+            it("fires nested setTimeout calls in user-created promises properly", function () {
+                var i = 0;
+                var clock = this.clock;
+
+                var callback = function () {
+                    global.Promise.resolve().then(function () {
+                        ++i;
+                        clock.setTimeout(function () {
+                            global.Promise.resolve().then(function () {
+                                callback();
+                            });
+                        }, 100);
+                    });
+                };
+
+                callback();
+
+                return clock.tickAsync(1000)
+                    .then(function () {
+                        assert.equals(i, 11);
+                    });
+            });
+
+            it("does not silently catch errors", function () {
+                var clock = this.clock;
+                var catchSpy = sinon.spy();
+
+                clock.setTimeout(function () {
+                    throw new Error("oh no!");
+                }, 1000);
+
+                return clock.tickAsync(1000)
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+                    });
+            });
+
+            it("returns the current now value", function () {
+                var clock = this.clock;
+                return clock.tickAsync(200).then(function (value) {
+                    assert.equals(clock.now, value);
+                });
+            });
+
+            it("is not influenced by forward system clock changes", function () {
+                var clock = this.clock;
+                var callback = function () {
+                    clock.setSystemTime((new clock.Date()).getTime() + 1000);
+                };
+                var stub = sinon.stub();
+                clock.setTimeout(callback, 1000);
+                clock.setTimeout(stub, 2000);
+                return clock.tickAsync(1990)
+                    .then(function () {
+                        assert.equals(stub.callCount, 0);
+                        return clock.tickAsync(20);
+                    }).then(function () {
+                        assert.equals(stub.callCount, 1);
+                    });
+            });
+
+            it("is not influenced by forward system clock changes in promises", function () {
+                var clock = this.clock;
+                var callback = function () {
+                    global.Promise.resolve().then(function () {
+                        clock.setSystemTime((new clock.Date()).getTime() + 1000);
+                    });
+                };
+                var stub = sinon.stub();
+                clock.setTimeout(callback, 1000);
+                clock.setTimeout(stub, 2000);
+                return clock.tickAsync(1990)
+                    .then(function () {
+                        assert.equals(stub.callCount, 0);
+                        return clock.tickAsync(20);
+                    }).then(function () {
+                        assert.equals(stub.callCount, 1);
+                    });
+            });
+
+            it("is not influenced by forward system clock changes when an error is thrown", function () {
+                var clock = this.clock;
+                var callback = function () {
+                    clock.setSystemTime((new clock.Date()).getTime() + 1000);
+                    throw new Error();
+                };
+                var stub = sinon.stub();
+                var catchSpy = sinon.spy();
+                clock.setTimeout(callback, 1000);
+                clock.setTimeout(stub, 2000);
+                return clock.tickAsync(1990)
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+                        assert.equals(stub.callCount, 0);
+                        return clock.tickAsync(20);
+                    }).then(function () {
+                        assert.equals(stub.callCount, 1);
+                    });
+            });
+
+            it("should settle user-created promises", function () {
+                var spy = sinon.spy();
+
+                setTimeout(function () {
+                    global.Promise.resolve().then(spy);
+                }, 100);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(spy.calledOnce);
+                    });
+            });
+
+            it("should settle chained user-created promises", function () {
+                var spies = [sinon.spy(), sinon.spy(), sinon.spy()];
+
+                setTimeout(function () {
+                    global.Promise.resolve()
+                        .then(spies[0])
+                        .then(spies[1])
+                        .then(spies[2]);
+                }, 100);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(spies[0].calledOnce);
+                        assert(spies[1].calledOnce);
+                        assert(spies[2].calledOnce);
+                    });
+            });
+
+            it("should settle multiple user-created promises", function () {
+                var spies = [sinon.spy(), sinon.spy(), sinon.spy()];
+
+                setTimeout(function () {
+                    global.Promise.resolve().then(spies[0]);
+                    global.Promise.resolve().then(spies[1]);
+                    global.Promise.resolve().then(spies[2]);
+                }, 100);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(spies[0].calledOnce);
+                        assert(spies[1].calledOnce);
+                        assert(spies[2].calledOnce);
+                    });
+            });
+
+            it("should settle nested user-created promises", function () {
+                var spy = sinon.spy();
+
+                setTimeout(function () {
+                    global.Promise.resolve().then(function () {
+                        global.Promise.resolve().then(function () {
+                            global.Promise.resolve().then(spy);
+                        });
+                    });
+                }, 100);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(spy.calledOnce);
+                    });
+            });
+
+            it("should settle user-created promises even if some throw", function () {
+                var spies = [sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()];
+
+                setTimeout(function () {
+                    global.Promise.reject().then(spies[0]).catch(spies[1]);
+                    global.Promise.resolve().then(spies[2]).catch(spies[3]);
+                }, 100);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(spies[0].notCalled);
+                        assert(spies[1].calledOnce);
+                        assert(spies[2].calledOnce);
+                        assert(spies[3].notCalled);
+                    });
+            });
+
+            it("should settle user-created promises before calling more timeouts", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+
+                setTimeout(function () {
+                    global.Promise.resolve().then(spies[0]);
+                }, 100);
+
+                setTimeout(spies[1], 200);
+
+                return this.clock.tickAsync(200)
+                    .then(function () {
+                        assert(spies[0].calledBefore(spies[1]));
+                    });
+            });
+
+            it("should settle local promises before calling timeouts", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+
+                global.Promise.resolve().then(spies[0]);
+
+                setTimeout(spies[1], 100);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(spies[0].calledBefore(spies[1]));
+                    });
+            });
+
+            it("should settle local nested promises before calling timeouts", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+
+                global.Promise.resolve().then(function () {
+                    global.Promise.resolve().then(function () {
+                        global.Promise.resolve().then(spies[0]);
+                    });
+                });
+
+                setTimeout(spies[1], 100);
+
+                return this.clock.tickAsync(100)
+                    .then(function () {
+                        assert(spies[0].calledBefore(spies[1]));
+                    });
+            });
+
+        });
+    }
+
     describe("next", function () {
 
         beforeEach(function () {
@@ -899,6 +1588,366 @@ describe("lolex", function () {
         });
     });
 
+    if (typeof global.Promise !== "undefined") {
+        describe("nextAsync", function () {
+
+            beforeEach(function () {
+                this.clock = lolex.install(0);
+            });
+
+            afterEach(function () {
+                this.clock.uninstall();
+            });
+
+            it("triggers the next timer", function () {
+                var stub = sinon.stub();
+                this.clock.setTimeout(stub, 100);
+
+                return this.clock.nextAsync()
+                    .then(function () {
+                        assert(stub.called);
+                    });
+            });
+
+            it("does not trigger simultaneous timers", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setTimeout(spies[0], 100);
+                this.clock.setTimeout(spies[1], 100);
+
+                return this.clock.nextAsync()
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert.isFalse(spies[1].called);
+                    });
+            });
+
+            it("subsequent calls trigger simultaneous timers", function () {
+                var spies = [sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()];
+                var clock = this.clock;
+                this.clock.setTimeout(spies[0], 100);
+                this.clock.setTimeout(spies[1], 100);
+                this.clock.setTimeout(spies[2], 99);
+                this.clock.setTimeout(spies[3], 100);
+
+                return this.clock.nextAsync()
+                    .then(function () {
+                        assert(spies[2].called);
+                        assert.isFalse(spies[0].called);
+                        assert.isFalse(spies[1].called);
+                        assert.isFalse(spies[3].called);
+                        return clock.nextAsync();
+                    }).then(function () {
+                        assert(spies[0].called);
+                        assert.isFalse(spies[1].called);
+                        assert.isFalse(spies[3].called);
+
+                        return clock.nextAsync();
+                    }).then(function () {
+                        assert(spies[1].called);
+                        assert.isFalse(spies[3].called);
+
+                        return clock.nextAsync();
+                    }).then(function () {
+                        assert(spies[3].called);
+                    });
+            });
+
+            it("subsequent calls triggers simultaneous timers with zero callAt", function () {
+                var test = this;
+                var spies = [
+                    sinon.spy(function () {
+                        test.clock.setTimeout(spies[1], 0);
+                    }),
+                    sinon.spy(),
+                    sinon.spy()
+                ];
+
+                // First spy calls another setTimeout with delay=0
+                this.clock.setTimeout(spies[0], 0);
+                this.clock.setTimeout(spies[2], 10);
+
+                return this.clock.nextAsync()
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert.isFalse(spies[1].called);
+
+                        return test.clock.nextAsync();
+                    }).then(function () {
+                        assert(spies[1].called);
+
+                        return test.clock.nextAsync();
+                    }).then(function () {
+                        assert(spies[2].called);
+                    });
+            });
+
+            it("subsequent calls in promises triggers simultaneous timers with zero callAt", function () {
+                var test = this;
+                var spies = [
+                    sinon.spy(function () {
+                        global.Promise.resolve().then(function () {
+                            test.clock.setTimeout(spies[1], 0);
+                        });
+                    }),
+                    sinon.spy(),
+                    sinon.spy()
+                ];
+
+                // First spy calls another setTimeout with delay=0
+                this.clock.setTimeout(spies[0], 0);
+                this.clock.setTimeout(spies[2], 10);
+
+                return this.clock.nextAsync()
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert.isFalse(spies[1].called);
+
+                        return test.clock.nextAsync();
+                    }).then(function () {
+                        assert(spies[1].called);
+
+                        return test.clock.nextAsync();
+                    }).then(function () {
+                        assert(spies[2].called);
+                    });
+            });
+
+            it("throws exception thrown by timer", function () {
+                var clock = this.clock;
+                var stub = sinon.stub().throws();
+                var catchSpy = sinon.spy();
+
+                clock.setTimeout(stub, 100);
+
+                return clock.nextAsync()
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+
+                        assert(stub.called);
+                    });
+            });
+
+            it("calls function with global object or null (strict mode) as this", function () {
+                var clock = this.clock;
+                var stub = sinon.stub().throws();
+                var catchSpy = sinon.spy();
+                clock.setTimeout(stub, 100);
+
+                return clock.nextAsync()
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+
+                        assert(stub.calledOn(global) || stub.calledOn(null));
+                    });
+            });
+
+            it("subsequent calls trigger in the order scheduled", function () {
+                var clock = this.clock;
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setTimeout(spies[0], 13);
+                this.clock.setTimeout(spies[1], 11);
+
+                return this.clock.nextAsync()
+                    .then(function () {
+                        return clock.nextAsync();
+                    }).then(function () {
+                        assert(spies[1].calledBefore(spies[0]));
+                    });
+            });
+
+            it("subsequent calls create updated Date", function () {
+                var clock = this.clock;
+                var spy = sinon.spy();
+
+                this.clock.setInterval(function () {
+                    spy(new Date().getTime());
+                }, 10);
+
+                return this.clock.nextAsync()
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(function () {
+                        assert.equals(spy.callCount, 10);
+                        assert(spy.calledWith(10));
+                        assert(spy.calledWith(20));
+                        assert(spy.calledWith(30));
+                        assert(spy.calledWith(40));
+                        assert(spy.calledWith(50));
+                        assert(spy.calledWith(60));
+                        assert(spy.calledWith(70));
+                        assert(spy.calledWith(80));
+                        assert(spy.calledWith(90));
+                        assert(spy.calledWith(100));
+                    });
+            });
+
+            it("subsequent calls in promises create updated Date", function () {
+                var clock = this.clock;
+                var spy = sinon.spy();
+
+                this.clock.setInterval(function () {
+                    global.Promise.resolve().then(function () {
+                        spy(new Date().getTime());
+                    });
+                }, 10);
+
+                return this.clock.nextAsync()
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(function () {
+                        assert.equals(spy.callCount, 10);
+                        assert(spy.calledWith(10));
+                        assert(spy.calledWith(20));
+                        assert(spy.calledWith(30));
+                        assert(spy.calledWith(40));
+                        assert(spy.calledWith(50));
+                        assert(spy.calledWith(60));
+                        assert(spy.calledWith(70));
+                        assert(spy.calledWith(80));
+                        assert(spy.calledWith(90));
+                        assert(spy.calledWith(100));
+                    });
+            });
+
+            it("subsequent calls trigger timeouts and intervals in the order scheduled", function () {
+                var clock = this.clock;
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setInterval(spies[0], 10);
+                this.clock.setTimeout(spies[1], 50);
+
+                return this.clock.nextAsync()
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(function () {
+                        assert(spies[0].calledBefore(spies[1]));
+                        assert.equals(spies[0].callCount, 5);
+                        assert.equals(spies[1].callCount, 1);
+                    });
+            });
+
+            it("subsequent calls do not fire canceled intervals", function () {
+                var id;
+                var clock = this.clock;
+                var callback = sinon.spy(function () {
+                    if (callback.callCount === 3) {
+                        clearInterval(id);
+                    }
+                });
+
+                id = this.clock.setInterval(callback, 10);
+                return this.clock.nextAsync()
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(function () {
+                        assert.equals(callback.callCount, 3);
+                    });
+            });
+
+            it("subsequent calls do not fire intervals canceled in promises", function () {
+                var id;
+                var clock = this.clock;
+                var callback = sinon.spy(function () {
+                    if (callback.callCount === 3) {
+                        global.Promise.resolve().then(function () {
+                            clearInterval(id);
+                        });
+                    }
+                });
+
+                id = this.clock.setInterval(callback, 10);
+                return this.clock.nextAsync()
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(clock.nextAsync)
+                    .then(function () {
+                        assert.equals(callback.callCount, 3);
+                    });
+            });
+
+            it("advances the clock based on when the timer was supposed to be called", function () {
+                var clock = this.clock;
+                clock.setTimeout(sinon.spy(), 55);
+                return clock.nextAsync()
+                    .then(function () {
+                        assert.equals(clock.now, 55);
+                    });
+            });
+
+            it("returns the current now value", function () {
+                var clock = this.clock;
+                clock.setTimeout(sinon.spy(), 55);
+                return clock.nextAsync()
+                    .then(function (value) {
+                        assert.equals(clock.now, value);
+                    });
+            });
+
+            it("should settle user-created promises", function () {
+                var spy = sinon.spy();
+
+                setTimeout(function () {
+                    global.Promise.resolve().then(spy);
+                }, 55);
+
+                return this.clock.nextAsync()
+                    .then(function () {
+                        assert(spy.calledOnce);
+                    });
+            });
+
+            it("should settle nested user-created promises", function () {
+                var spy = sinon.spy();
+
+                setTimeout(function () {
+                    global.Promise.resolve().then(function () {
+                        global.Promise.resolve().then(function () {
+                            global.Promise.resolve().then(spy);
+                        });
+                    });
+                }, 55);
+
+                return this.clock.nextAsync()
+                    .then(function () {
+                        assert(spy.calledOnce);
+                    });
+            });
+
+            it("should settle local promises before firing timers", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+
+                global.Promise.resolve().then(spies[0]);
+
+                setTimeout(spies[1], 55);
+
+                return this.clock.nextAsync()
+                    .then(function () {
+                        assert(spies[0].calledBefore(spies[1]));
+                    });
+            });
+
+        });
+    }
+
     describe("runAll", function () {
 
         it("if there are no timers just return", function () {
@@ -980,6 +2029,205 @@ describe("lolex", function () {
         });
 
     });
+
+    if (typeof global.Promise !== "undefined") {
+        describe("runAllAsync", function () {
+
+            it("if there are no timers just return", function () {
+                this.clock = lolex.createClock();
+                return this.clock.runAllAsync();
+            });
+
+            it("runs all timers", function () {
+                this.clock = lolex.createClock();
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setTimeout(spies[0], 10);
+                this.clock.setTimeout(spies[1], 50);
+
+                return this.clock.runAllAsync()
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert(spies[1].called);
+                    });
+            });
+
+            it("new timers added while running are also run", function () {
+                this.clock = lolex.createClock();
+                var test = this;
+                var spies = [
+                    sinon.spy(function () {
+                        test.clock.setTimeout(spies[1], 50);
+                    }),
+                    sinon.spy()
+                ];
+
+                // Spy calls another setTimeout
+                this.clock.setTimeout(spies[0], 10);
+
+                return this.clock.runAllAsync()
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert(spies[1].called);
+                    });
+            });
+
+            it("new timers added in promises while running are also run", function () {
+                this.clock = lolex.createClock();
+                var test = this;
+                var spies = [
+                    sinon.spy(function () {
+                        global.Promise.resolve().then(function () {
+                            test.clock.setTimeout(spies[1], 50);
+                        });
+                    }),
+                    sinon.spy()
+                ];
+
+                // Spy calls another setTimeout
+                this.clock.setTimeout(spies[0], 10);
+
+                return this.clock.runAllAsync()
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert(spies[1].called);
+                    });
+            });
+
+            it("throws before allowing infinite recursion", function () {
+                this.clock = lolex.createClock();
+                var test = this;
+                var recursiveCallback = function () {
+                    test.clock.setTimeout(recursiveCallback, 10);
+                };
+                var catchSpy = sinon.spy();
+
+                this.clock.setTimeout(recursiveCallback, 10);
+
+                return test.clock.runAllAsync()
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+                    });
+            });
+
+            it("throws before allowing infinite recursion from promises", function () {
+                this.clock = lolex.createClock();
+                var test = this;
+                var recursiveCallback = function () {
+                    global.Promise.resolve().then(function () {
+                        test.clock.setTimeout(recursiveCallback, 10);
+                    });
+                };
+                var catchSpy = sinon.spy();
+
+                this.clock.setTimeout(recursiveCallback, 10);
+
+                return test.clock.runAllAsync()
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+                    });
+            });
+
+            it("the loop limit can be set when creating a clock", function () {
+                this.clock = lolex.createClock(0, 1);
+                var test = this;
+                var catchSpy = sinon.spy();
+
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setTimeout(spies[0], 10);
+                this.clock.setTimeout(spies[1], 50);
+
+                return test.clock.runAllAsync()
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+                    });
+            });
+
+            it("the loop limit can be set when installing a clock", function () {
+                this.clock = lolex.install(0, null, null, 1);
+                var test = this;
+                var catchSpy = sinon.spy();
+
+                var spies = [sinon.spy(), sinon.spy()];
+                setTimeout(spies[0], 10);
+                setTimeout(spies[1], 50);
+
+                return test.clock.runAllAsync()
+                    .catch(catchSpy)
+                    .then(function () {
+                        assert(catchSpy.calledOnce);
+
+                        test.clock.uninstall();
+                    });
+
+            });
+
+            it("should settle user-created promises", function () {
+                this.clock = lolex.createClock();
+                var spy = sinon.spy();
+
+                this.clock.setTimeout(function () {
+                    global.Promise.resolve().then(spy);
+                }, 55);
+
+                return this.clock.runAllAsync()
+                    .then(function () {
+                        assert(spy.calledOnce);
+                    });
+            });
+
+            it("should settle nested user-created promises", function () {
+                this.clock = lolex.createClock();
+                var spy = sinon.spy();
+
+                this.clock.setTimeout(function () {
+                    global.Promise.resolve().then(function () {
+                        global.Promise.resolve().then(function () {
+                            global.Promise.resolve().then(spy);
+                        });
+                    });
+                }, 55);
+
+                return this.clock.runAllAsync()
+                    .then(function () {
+                        assert(spy.calledOnce);
+                    });
+            });
+
+            it("should settle local promises before firing timers", function () {
+                this.clock = lolex.createClock();
+                var spies = [sinon.spy(), sinon.spy()];
+
+                global.Promise.resolve().then(spies[0]);
+
+                this.clock.setTimeout(spies[1], 55);
+
+                return this.clock.runAllAsync()
+                    .then(function () {
+                        assert(spies[0].calledBefore(spies[1]));
+                    });
+            });
+
+            it("should settle user-created promises before firing more timers", function () {
+                this.clock = lolex.createClock();
+                var spies = [sinon.spy(), sinon.spy()];
+
+                this.clock.setTimeout(function () {
+                    global.Promise.resolve().then(spies[0]);
+                }, 55);
+
+                this.clock.setTimeout(spies[1], 75);
+
+                return this.clock.runAllAsync()
+                    .then(function () {
+                        assert(spies[0].calledBefore(spies[1]));
+                    });
+            });
+
+        });
+    }
 
     describe("runToLast", function () {
 
@@ -1084,6 +2332,249 @@ describe("lolex", function () {
         });
 
     });
+
+    if (typeof global.Promise !== "undefined") {
+        describe("runToLastAsync", function () {
+
+            it("returns current time when there are no timers", function () {
+                this.clock = lolex.createClock();
+
+                return this.clock.runToLastAsync()
+                    .then(function (time) {
+                        assert.equals(time, 0);
+                    });
+            });
+
+            it("runs all existing timers", function () {
+                this.clock = lolex.createClock();
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setTimeout(spies[0], 10);
+                this.clock.setTimeout(spies[1], 50);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert(spies[1].called);
+                    });
+            });
+
+            it("returns time of the last timer", function () {
+                this.clock = lolex.createClock();
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setTimeout(spies[0], 10);
+                this.clock.setTimeout(spies[1], 50);
+
+                return this.clock.runToLastAsync()
+                    .then(function (time) {
+                        assert.equals(time, 50);
+                    });
+            });
+
+            it("runs all existing timers when two timers are matched for being last", function () {
+                this.clock = lolex.createClock();
+                var spies = [sinon.spy(), sinon.spy()];
+                this.clock.setTimeout(spies[0], 10);
+                this.clock.setTimeout(spies[1], 10);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert(spies[0].called);
+                        assert(spies[1].called);
+                    });
+            });
+
+            it("new timers added with a call time later than the last existing timer are NOT run", function () {
+                this.clock = lolex.createClock();
+                var test = this;
+                var spies = [
+                    sinon.spy(function () {
+                        test.clock.setTimeout(spies[1], 50);
+                    }),
+                    sinon.spy()
+                ];
+
+                // Spy calls another setTimeout
+                this.clock.setTimeout(spies[0], 10);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert.isTrue(spies[0].called);
+                        assert.isFalse(spies[1].called);
+                    });
+            });
+
+            it("new timers added from a promise with a call time later than the last existing timer" +
+                    "are NOT run", function () {
+                this.clock = lolex.createClock();
+                var test = this;
+                var spies = [
+                    sinon.spy(function () {
+                        global.Promise.resolve().then(function () {
+                            test.clock.setTimeout(spies[1], 50);
+                        });
+                    }),
+                    sinon.spy()
+                ];
+
+                // Spy calls another setTimeout
+                this.clock.setTimeout(spies[0], 10);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert.isTrue(spies[0].called);
+                        assert.isFalse(spies[1].called);
+                    });
+            });
+
+            it("new timers added with a call time ealier than the last existing timer are run", function () {
+                this.clock = lolex.createClock();
+                var test = this;
+                var spies = [
+                    sinon.spy(),
+                    sinon.spy(function () {
+                        test.clock.setTimeout(spies[2], 50);
+                    }),
+                    sinon.spy()
+                ];
+
+                this.clock.setTimeout(spies[0], 100);
+                // Spy calls another setTimeout
+                this.clock.setTimeout(spies[1], 10);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert.isTrue(spies[0].called);
+                        assert.isTrue(spies[1].called);
+                        assert.isTrue(spies[2].called);
+                    });
+            });
+
+            it("new timers added from a promise with a call time ealier than the last existing timer" +
+                    "are run", function () {
+                this.clock = lolex.createClock();
+                var test = this;
+                var spies = [
+                    sinon.spy(),
+                    sinon.spy(function () {
+                        global.Promise.resolve().then(function () {
+                            test.clock.setTimeout(spies[2], 50);
+                        });
+                    }),
+                    sinon.spy()
+                ];
+
+                this.clock.setTimeout(spies[0], 100);
+                // Spy calls another setTimeout
+                this.clock.setTimeout(spies[1], 10);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert.isTrue(spies[0].called);
+                        assert.isTrue(spies[1].called);
+                        assert.isTrue(spies[2].called);
+                    });
+            });
+
+            it("new timers cannot cause an infinite loop", function () {
+                this.clock = lolex.createClock();
+                var test = this;
+                var spy = sinon.spy();
+                var recursiveCallback = function () {
+                    test.clock.setTimeout(recursiveCallback, 0);
+                };
+
+                this.clock.setTimeout(recursiveCallback, 0);
+                this.clock.setTimeout(spy, 100);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert.isTrue(spy.called);
+                    });
+            });
+
+            it("new timers created from promises cannot cause an infinite loop", function () {
+                this.clock = lolex.createClock();
+                var test = this;
+                var spy = sinon.spy();
+                var recursiveCallback = function () {
+                    global.Promise.resolve().then(function () {
+                        test.clock.setTimeout(recursiveCallback, 0);
+                    });
+                };
+
+                this.clock.setTimeout(recursiveCallback, 0);
+                this.clock.setTimeout(spy, 100);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert.isTrue(spy.called);
+                    });
+            });
+
+            it("should settle user-created promises", function () {
+                this.clock = lolex.createClock();
+                var spy = sinon.spy();
+
+                this.clock.setTimeout(function () {
+                    global.Promise.resolve().then(spy);
+                }, 55);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert(spy.calledOnce);
+                    });
+            });
+
+            it("should settle nested user-created promises", function () {
+                this.clock = lolex.createClock();
+                var spy = sinon.spy();
+
+                this.clock.setTimeout(function () {
+                    global.Promise.resolve().then(function () {
+                        global.Promise.resolve().then(function () {
+                            global.Promise.resolve().then(spy);
+                        });
+                    });
+                }, 55);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert(spy.calledOnce);
+                    });
+            });
+
+            it("should settle local promises before firing timers", function () {
+                this.clock = lolex.createClock();
+                var spies = [sinon.spy(), sinon.spy()];
+
+                global.Promise.resolve().then(spies[0]);
+
+                this.clock.setTimeout(spies[1], 55);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert(spies[0].calledBefore(spies[1]));
+                    });
+            });
+
+            it("should settle user-created promises before firing more timers", function () {
+                this.clock = lolex.createClock();
+                var spies = [sinon.spy(), sinon.spy()];
+
+                this.clock.setTimeout(function () {
+                    global.Promise.resolve().then(spies[0]);
+                }, 55);
+
+                this.clock.setTimeout(spies[1], 75);
+
+                return this.clock.runToLastAsync()
+                    .then(function () {
+                        assert(spies[0].calledBefore(spies[1]));
+                    });
+            });
+
+        });
+    }
 
     describe("clearTimeout", function () {
 


### PR DESCRIPTION
### Summary

This pull request adds `tickAsync()`, `nextAsync()`, `runAllAsync()`, `runToLastAsync()` to parallel the existing synchronous calls. These new calls all return promises that resolve with what the synchronous call would have resolved with or reject with whatever error the synchronous call would have thrown.

This pull request obviously requires feedback from the core lolex team, so I'm  happy to make any changes that might come up.

### Goal

The goal of these functions is to provide those writing tests with tools to test code that uses promises without having to work around the fact that lolex executes all timers synchronously in a row.

### Example

Consider these timers:

```javascript
var result: = null;
setTimeout(async function () {
    result = await Promise.resolve(50);
}, 1000);
setTimeout(function () {
    assert(result === 50);
}, 2000);
```

Under normal circumstances, the promise callback would be executed immediately once the first timer is done executing, giving the second timer access to `result`. The order would be:
```
1) timeoutCallback1
2) promiseCallback
3) timeoutCallback2
```

However when using lolex to simulate time with:

```javascript
clock.tick(2000);
```
causes the callbacks to be called in this order:
```
1) timeoutCallback1
2) timeoutCallback2
3) (synchronous return to test context and subsequent assertions)
4) promiseCallback
```

With these new async functions, you would simulate time with:
```javascript
await clock.tickAsync(2000);
```

which would cause the callbacks to be called in this order:
```
1) timeoutCallback1
2) promiseCallback
3) timeoutCallback2
4) (asynchronous return to test context and subsequent assertions)
```

This
a) properly simulates the js engine's event loop when promises are involved, and
b) allows assertions to be checked after the promise returned by `clock.*Async()` has settled.

### Implementation details:

These calls rely on the native `setImmediate()` and semi-rely on the behavior of the js engine to execute asynchronous callbacks in this order:

```
process.nextTick -> promise callbacks -> set* timers
```

### Considerations

* I have `tick()` and `tickAsync()` proxying to a `doTick()` so that they can share code, since `tick()` was the largest of the current calls. If it's preferable to separate them, I'll be happy to do that.

* Right now you can surround `tick()` with a try/catch in order to catch any errors that the timers might throw. If one is thrown, `tick()` will rethrow the first thrown after all timer callbacks are executed. Users of `tickAsync()` might also think this would catch any errors that a promise might throw, especially if the error is unhandled by user code. However, this would not be the case (and cannot be since we let the system event loop execute the promise callbacks). I don't think there's any workaround to this, other than to just know it exists and to add it to the documentation. The user will have to test for errors directly using the promise that rejected with it.

* Above, I mentioned that it semi-relies on that order. When using native promises, if that order is used by the js engine, then all promise callbacks created from a timer and any promise callbacks that get queue from those callbacks (etc for all nested callbacks) will be fully executed before the next timer is called by lolex. This obviously relies on the js engine executing promise callbacks until none are available before calling any set* timer callbacks. If the user is using a promise polyfill that relies on setImmediate, however, then it will not possible to execute all callbacks, because lolex must push a callback onto the set* timer stack before giving up control to let the js engine process any pending promise callbacks. If those promise callbacks create more promise callbacks, then they will be after the lolex callback in the queue and thus not possible to execute reliably.

* I have `if` statements surrounding all async code. The `if` statement is checking for the presence of `global.Promise`. However, these methods don't have to rely on promises. They could just as easily accept a callback and return nothing. The theoretical callback-based async methods could then just be wrapped in a `promisify` call for users that want to use them as promises.
I don't know how much this makes sense though, since these new async calls were created specifically to handle promises created in a timer, and they don't work as reliably for async code that uses the `setImmediate` family.
If a user is testing code in an environment without native promises and they are using callbacks, they are testing code that either
a) is not strictly async (does everything in the same event tick)
b) uses `process.nextTick` or `setImmediate/setTimeout` or
c) relies on native async calls like `fs.open()`.
As I mentioned, these methods can't reliably handle the `setImmediate` family and any code relying on engine-level async code wouldn't really be able to use lolex anyways.
Therefore the only situation that a callback version makes sense would be in an environment where there aren't native promises and the user is testing asynchronous code that relies on `process.nextTick`. I don't know how common this is so I don't know if it's worth pursuing. I'm also of the opinion that new code should be using promises wherever possible, but I know this is a library so I'll let you as the core team decide if there should be a callback version.

(Side note: I've included my other pull request's commit with this one so there won't be a merge conflict later since they're modifying the same code. If that pull request ends up being rejected, I'll remove that code from this one)