### PR TITLE
Add support for performance.now

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -165,6 +165,10 @@ Clears the timer given the ID or timer object, as long as it was created using
 ### `clock.hrtime(prevTime?)`
 Only available in Node.JS, mimicks process.hrtime().
 
+### `clock.performance.now()`
+Only available in browser environments, mimicks performance.now().
+
+
 ### `clock.tick(time)`
 
 Advance the clock, firing callbacks if necessary. `time` may be the number of
@@ -213,6 +217,10 @@ Restores the original methods on the `context` that was passed to
 ### `Date`
 
 Implements the `Date` object but using the clock to provide the correct time.
+
+### `Performance`
+
+Implements the `now` method of the [`Performance`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) object but using the clock to provide the correct time. Only available in environments that support the Performance object (browsers mostly).
 
 ## Running tests
 

--- a/lolex.js
+++ b/lolex.js
@@ -30,6 +30,8 @@ var NOOP = function () { return undefined; };
 var timeoutResult = setTimeout(NOOP, 0);
 var addTimerReturnsObject = typeof timeoutResult === "object";
 var hrtimePresent = (global.process && typeof global.process.hrtime === "function");
+var performancePresent = (global.performance && typeof global.performance.now === "function");
+
 clearTimeout(timeoutResult);
 
 var NativeDate = Date;
@@ -410,6 +412,10 @@ if (hrtimePresent) {
     timers.hrtime = global.process.hrtime;
 }
 
+if (performancePresent) {
+    timers.performance = global.performance;
+}
+
 var keys = Object.keys || function (obj) {
     var ks = [];
     var key;
@@ -589,6 +595,12 @@ function createClock(now, loopLimit) {
         }
     };
 
+    if (performancePresent) {
+        clock.performance = Object.create(global.performance);
+        clock.performance.now = function nowTime() {
+            return clock.hrNow;
+        };
+    }
     if (hrtimePresent) {
         clock.hrtime = function (prev) {
             if (Array.isArray(prev)) {

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "prepublish": "npm run bundle"
   },
   "devDependencies": {
-    "browserify": "^14.1.0",
+    "browserify": "^14.4.0",
     "eslint": "^3.16.1",
     "eslint-config-sinon": "^1.0.0",
     "eslint-plugin-mocha": "^4.8.0",
-    "mocha": "^3.2.0",
-    "mochify": "^3.0.0",
+    "mocha": "^3.4.2",
+    "mochify": "^3.3.0",
     "referee": "^1.2.0",
-    "sinon": "^1.17.4"
+    "sinon": "^1.17.7"
   },
   "eslintConfig": {
     "extends": "eslint-config-sinon"

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -28,6 +28,8 @@ var NOOP = function () { return undefined; };
 var timeoutResult = setTimeout(NOOP, 0);
 var addTimerReturnsObject = typeof timeoutResult === "object";
 var hrtimePresent = (global.process && typeof global.process.hrtime === "function");
+var performancePresent = (global.performance && typeof global.performance.now === "function");
+
 clearTimeout(timeoutResult);
 
 var NativeDate = Date;
@@ -408,6 +410,10 @@ if (hrtimePresent) {
     timers.hrtime = global.process.hrtime;
 }
 
+if (performancePresent) {
+    timers.performance = global.performance;
+}
+
 var keys = Object.keys || function (obj) {
     var ks = [];
     var key;
@@ -587,6 +593,12 @@ function createClock(now, loopLimit) {
         }
     };
 
+    if (performancePresent) {
+        clock.performance = Object.create(global.performance);
+        clock.performance.now = function lolexNow() {
+            return clock.hrNow;
+        };
+    }
     if (hrtimePresent) {
         clock.hrtime = function (prev) {
             if (Array.isArray(prev)) {


### PR DESCRIPTION
This pull request adds support (and tests) for `performance.now` in browser envrionments.

Fixes https://github.com/sinonjs/lolex/issues/82