### PR TITLE
Add myself to authors list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Nando <fdanko@ekumenlabs.com>
 Simen Bekkhus <sbekkhus91@gmail.com>
 Sylvain Fraïssé <fraisse.sylvain@gmail.com>
 Thibault Hild <gautaz@users.noreply.github.com>
+Benjamin Gruenbaum <benji@peer5.com>


### PR DESCRIPTION
I just found out there is this file here - I assume it is used so people can contact authors of commits in case there is a problem - so adding my name and work address at Peer5 here. I also intend to actively help maintain lolex (as needed) as part of my job @ Peer5 :)