### PR TITLE
Remove try/catch that captures exception

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -286,26 +286,11 @@ function callTimer(clock, timer) {
         delete clock.timers[timer.id];
     }
 
-    try {
-        if (typeof timer.func === "function") {
-            timer.func.apply(null, timer.args);
-        } else {
-            /* eslint no-eval: "off" */
-            eval(timer.func);
-        }
-    } catch (e) {
-        exception = e;
-    }
-
-    if (!clock.timers[timer.id]) {
-        if (exception) {
-            throw exception;
-        }
-        return;
-    }
-
-    if (exception) {
-        throw exception;
+    if (typeof timer.func === "function") {
+        timer.func.apply(null, timer.args);
+    } else {
+        /* eslint no-eval: "off" */
+        eval(timer.func);
     }
 }
 


### PR DESCRIPTION
I might not understand what that code does - but it looks like leftoff from previous versions of the code. 

I see no case in which there is an exception and it's not thrown - and the `if` seems redundant at which point we might as well avoid the try/catch. 