### PR TITLE
issue #67 - overflowing the timer correctly according to int32_t

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -2,6 +2,7 @@
 
 var userAgent = global.navigator && global.navigator.userAgent;
 var isRunningInIE = userAgent && userAgent.indexOf("MSIE ") > -1;
+var maxTimeout = Math.pow(2, 31) - 1; //see https://heycam.github.io/webidl/#abstract-opdef-converttoint
 
 // Make properties writable in IE, as per
 // http://www.adequatelygood.com/Replacing-setTimeout-Globally.html
@@ -188,6 +189,14 @@ function runJobs(clock) {
 function addTimer(clock, timer) {
     if (timer.func === undefined) {
         throw new Error("Callback must be provided to timer calls");
+    }
+
+    if (timer.hasOwnProperty("delay")) {
+        timer.delay = timer.delay > maxTimeout ? 1 : timer.delay;
+    }
+
+    if (timer.hasOwnProperty("interval")) {
+        timer.interval = timer.interval > maxTimeout ? 1 : timer.interval;
     }
 
     if (!clock.timers) {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -53,6 +53,50 @@ describe("issue #73", function () {
     });
 });
 
+describe("issue #67", function () {
+    // see https://nodejs.org/api/timers.html
+    it("should overflow to 1 on very big timeouts", function () {
+        var clock = lolex.install();
+        var stub1 = sinon.stub();
+        var stub2 = sinon.stub();
+
+        clock.setTimeout(stub1, 100);
+        clock.setTimeout(stub2, 214748334700); //should be called after 1 tick
+
+        clock.tick(1);
+        assert(stub2.called);
+        assert.isFalse(stub1.called);
+
+        clock.tick(99);
+        assert(stub1.called);
+        assert(stub2.called);
+
+        clock.uninstall();
+    });
+
+    it("should overflow to interval 1 on very big timeouts", function () {
+        var clock = lolex.install();
+        var stub = sinon.stub();
+
+        clock.setInterval(stub, 214748334700);
+        clock.tick(3);
+        assert(stub.calledThrice);
+
+        clock.uninstall();
+    });
+
+    it("should execute setTimeout smaller than 1", function () {
+        var clock = lolex.install();
+        var stub1 = sinon.stub();
+
+        clock.setTimeout(stub1, 0.5);
+        clock.tick(1);
+        assert(stub1.calledOnce);
+
+        clock.uninstall();
+    });
+});
+
 describe("lolex", function () {
 
     describe("setTimeout", function () {


### PR DESCRIPTION
i did not change the logic for handling `setTimeout` with a value which is smaller than 1. I think this is redundant since some users might be using `setTimeout` with a value of 0, then `tick()`ing it might result in an unexpected sequence of timers being executed. There's one test that demonstrates this (`"calls the given callback before setTimeout"`).
not sure if we need to change this edge case.