### PR TITLE
issue #126 - do not attach `nextTick` by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 .DS_Store
+.idea

--- a/Readme.md
+++ b/Readme.md
@@ -142,7 +142,7 @@ Parameter | Type | Default | Description
 --------- | ---- | ------- | ------------
 `config.target`| Object | global | installs lolex onto the specified target context 
 `config.now` | Number/Date | 0 | installs lolex with the specified unix epoch 
-`config.toFake` | String[] | [] | an array with explicit function names to hijack. You can pick from `setTimeout`, `clearTimeout`, `setImmediate`, `clearImmediate`,`setInterval`, `clearInterval`, and `Date`. E.g. `lolex.install({ toFake: ["setTimeout","clearTimeout"]})`
+`config.toFake` | String[] | ["setTimeout", "clearTimeout", "setImmediate", "clearImmediate","setInterval", "clearInterval", "Date"] | an array with explicit function names to hijack. *When not set, lolex will automatically fake all methods **except** `nextTick`* e.g., `lolex.install({ toFake: ["setTimeout","nextTick"]})` will fake only `setTimeout` and `nextTick`
 `config.loopLimit` | Number | 1000 | the maximum number of timers that will be run when calling runAll()
 `config.shouldAdvanceTime` | Boolean | false | tells lolex to increment mocked time automatically based on the real system time shift (e.g. the mocked time will be incremented by 20ms for every 20ms change in the real system time)
 `config.advanceTimeDelta` | Number | 20 | relevant only when using with `shouldAdvanceTime: true`. increment mocked time by `advanceTimeDelta` ms every `advanceTimeDelta` ms change in the real system time.

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -689,7 +689,8 @@ exports.install = function install(config) {
     clock.methods = config.toFake || [];
 
     if (clock.methods.length === 0) {
-        clock.methods = keys(timers);
+        // do not fake nextTick by default - GitHub#126
+        clock.methods = keys(timers).filter(function (key) {return key !== "nextTick";});
     }
 
     for (i = 0, l = clock.methods.length; i < l; i++) {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -2016,17 +2016,18 @@ describe("lolex", function () {
             });
 
             it("installs with microticks", function () {
-                this.clock = lolex.install();
+                var clock = lolex.install({toFake: ["nextTick"]});
                 var called = false;
                 process.nextTick(function () {
                     called = true;
                 });
-                this.clock.runAll();
+                clock.runAll();
                 assert(called);
+                clock.uninstall();
             });
 
             it("installs with microticks and timers in order", function () {
-                var clock = this.clock = lolex.install();
+                var clock = lolex.install({toFake: ["nextTick", "setTimeout"]});
                 var order = [];
                 setTimeout(function () {
                     order.push("timer-1");
@@ -2041,10 +2042,11 @@ describe("lolex", function () {
                 assert.same(order[0], "timer-1");
                 assert.same(order[1], "tick");
                 assert.same(order[2], "timer-2");
+                clock.uninstall();
             });
 
             it("uninstalls", function () {
-                var clock = this.clock = lolex.install();
+                var clock = lolex.install({toFake: ["nextTick"]});
                 clock.uninstall();
                 var called = false;
                 process.nextTick(function () {
@@ -2055,13 +2057,27 @@ describe("lolex", function () {
             });
 
             it("passes arguments when installed - GitHub#122", function () {
-                var clock = this.clock = lolex.install();
+                var clock = lolex.install({toFake: ["nextTick"]});
                 var called = false;
                 process.nextTick(function (value) {
                     called = value;
                 }, true);
                 clock.runAll();
                 assert(called);
+                clock.uninstall();
+            });
+
+            it("does not install by default - GitHub#126", function (done) {
+                var clock = lolex.install();
+                var spy = sinon.spy(clock, "nextTick");
+                var called = false;
+                process.nextTick(function (value) {
+                    called = value;
+                    assert(called);
+                    assert(!spy.called);
+                    clock.uninstall();
+                    done();
+                }, true);
             });
         });
     }


### PR DESCRIPTION
resolves #126 
- does not fake process.nextTick by default
- added .idea folder to .gitignore
- added missing clock teardowns after installs