### PR TITLE
Stops leak of (request|cancel)AnimationFrame into global scope.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "lint": "eslint .",
-    "test-node": "mocha -R dot",
+    "test-node": "mocha -R dot --check-leaks",
     "test-headless": "mochify",
     "test-cloud": "mochify --wd",
     "test": "npm run lint && npm run test-node && npm run test-headless",

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -31,6 +31,8 @@ var addTimerReturnsObject = typeof timeoutResult === "object";
 var hrtimePresent = (global.process && typeof global.process.hrtime === "function");
 var nextTickPresent = (global.process && typeof global.process.nextTick === "function");
 var performancePresent = (global.performance && typeof global.performance.now === "function");
+var requestAnimationFramePresent = (global.requestAnimationFrame && typeof global.requestAnimationFrame === "function");
+var cancelAnimationFramePresent = (global.cancelAnimationFrame && typeof global.cancelAnimationFrame === "function");
 
 clearTimeout(timeoutResult);
 
@@ -436,8 +438,6 @@ var timers = {
     clearImmediate: global.clearImmediate,
     setInterval: setInterval,
     clearInterval: clearInterval,
-    requestAnimationFrame: global.requestAnimationFrame,
-    cancelAnimationFrame: global.cancelAnimationFrame,
     Date: Date
 };
 
@@ -451,6 +451,14 @@ if (nextTickPresent) {
 
 if (performancePresent) {
     timers.performance = global.performance;
+}
+
+if (requestAnimationFramePresent) {
+    timers.requestAnimationFrame = global.requestAnimationFrame;
+}
+
+if (cancelAnimationFramePresent) {
+    timers.cancelAnimationFrame = global.cancelAnimationFrame;
 }
 
 var keys = Object.keys || function (obj) {


### PR DESCRIPTION
Also adds --check-leaks flag to mocha test runs.

Fixes #142 