### PR TITLE
Add missing functions in default `toFake`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -139,7 +139,7 @@ Parameter | Type | Default | Description
 --------- | ---- | ------- | ------------
 `config.target`| Object | global | installs lolex onto the specified target context
 `config.now` | Number/Date | 0 | installs lolex with the specified unix epoch
-`config.toFake` | String[] | ["setTimeout", "clearTimeout", "setImmediate", "clearImmediate","setInterval", "clearInterval", "Date"] | an array with explicit function names to hijack. *When not set, lolex will automatically fake all methods **except** `nextTick`* e.g., `lolex.install({ toFake: ["setTimeout","nextTick"]})` will fake only `setTimeout` and `nextTick`
+`config.toFake` | String[] | ["setTimeout", "clearTimeout", "setImmediate", "clearImmediate","setInterval", "clearInterval", "Date", "requestAnimationFrame", "cancelAnimationFrame", "hrtime"] | an array with explicit function names to hijack. *When not set, lolex will automatically fake all methods **except** `nextTick`* e.g., `lolex.install({ toFake: ["setTimeout","nextTick"]})` will fake only `setTimeout` and `nextTick`
 `config.loopLimit` | Number | 1000 | the maximum number of timers that will be run when calling runAll()
 `config.shouldAdvanceTime` | Boolean | false | tells lolex to increment mocked time automatically based on the real system time shift (e.g. the mocked time will be incremented by 20ms for every 20ms change in the real system time)
 `config.advanceTimeDelta` | Number | 20 | relevant only when using with `shouldAdvanceTime: true`. increment mocked time by `advanceTimeDelta` ms every `advanceTimeDelta` ms change in the real system time.


### PR DESCRIPTION
I _think_ this is correct.

It would be great if I was able to pass `true` or `'all'` or something, so that I can get all future added timers for free even though I opt in to fake `nextTick`.

It seems like methods are only added if  they exist in the original global, even though they are specified in `toFake`. Is this understanding correct? Should it be clarified in the docs either way?