### PR TITLE
Add files section to package.json to avoid unnecessary package bloat

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
   "lint-staged": {
     "*.js": "eslint"
   },
+  "files": [
+    "src/",
+    "lolex.js"
+  ],
   "devDependencies": {
     "browserify": "14.4.0",
     "eslint": "4.2.0",


### PR DESCRIPTION
This prevents unnecessary files to be published to the npm registry, saving bandwidth and speeding up installs for everyone.

#### Before

```text
du -h lolex-2.3.1.tgz
108K	lolex-2.3.1.tgz
```

#### After 

```text
du -h lolex-2.3.1.tgz
 20K	lolex-2.3.1.tgz
```

With [~4.6M downloads/month](https://www.npmjs.com/package/lolex), this will save `4,600,000 * 88,000 / 1024^3 = ~376GB/month`

#### How to verify

1. Check out this branch
1. `npm pack`
1. Expand the package
1. Observe that `lolex.js` is in root, and that `src/` still contains `lolex-src.js`