### PR TITLE
Allow configuring if lolex should return DOM or node timers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -261,6 +261,10 @@ setSystemTime().
 Restores the original methods on the `target` that was passed to
 `lolex.install`, or the native timers if no `target` was given.
 
+### `lolex.setTimersReturnsObjects(boolean)`
+
+Changes whether or not timers should return objects (like Node native timers) or integer IDs (like DOM timers).
+
 ### `Date`
 
 Implements the `Date` object but using the clock to provide the correct time.

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -738,6 +738,12 @@ function createClock(start, loopLimit) {
 }
 exports.createClock = createClock;
 
+exports.setTimersReturnsObjects = function(value) {
+    var oldValue = addTimerReturnsObject;
+    addTimerReturnsObject = value;
+    return oldValue;
+};
+
 /**
  * @param config {Object} optional config
  * @param config.target {Object} the target to install timers in (default `window`)

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1726,6 +1726,22 @@ describe("lolex", function () {
             }
         });
 
+        it("Configuring the type of timers", function () {
+            this.clock = lolex.install();
+            var stub = sinon.stub();
+
+            var oldValue = lolex.setTimersReturnsObjects(true);
+            var to = setTimeout(stub, 1000);
+            assert.isNumber(to.id);
+            assert.isFunction(to.ref);
+            assert.isFunction(to.unref);
+            var returnValue = lolex.setTimersReturnsObjects(false);
+            assert.isTrue(returnValue);
+            var to = setTimeout(stub, 1000);
+            assert.isNumber(to);
+            lolex.setTimersReturnsObjects(oldValue);
+        });
+
         it("replaces global clearTimeout", function () {
             this.clock = lolex.install();
             var stub = sinon.stub();


### PR DESCRIPTION
Fixes (possibly) https://github.com/sinonjs/lolex/issues/146

CC @SimenB - let me know if this addresses your environment configuration issue with `global` or if a more general workaround (passing the library) is still required - this just felt less flakey to me.

CC @fatso83 