### PR TITLE
Fix that performance.mark is undefined after timer install

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -710,6 +710,15 @@ function createClock(start, loopLimit) {
 
     if (performancePresent) {
         clock.performance = Object.create(global.performance);
+
+        var proto = Performance.prototype;
+
+        Object
+            .getOwnPropertyNames(global.Performance.prototype)
+            .forEach(function (name) {
+                clock.performance[name] = proto[name];
+            });
+
         clock.performance.now = function lolexNow() {
             return clock.hrNow;
         };

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1833,6 +1833,26 @@ describe("lolex", function () {
                 this.clock.uninstall();
                 assert.same(performance.now, oldNow);
             });
+
+            it("keeps original performance's all prototype methods after being installed", function () {
+                // In Phantom.js environment, Performance.prototype has only "now" method.
+                // For testing, some stub functions need to be assigned.
+                Performance.prototype.someFunc1 = function () {};
+                Performance.prototype.someFunc2 = function () {};
+                Performance.prototype.someFunc3 = function () {};
+
+                this.clock = lolex.install();
+
+                assert.isFunction(performance.someFunc1);
+                assert.isFunction(performance.someFunc2);
+                assert.isFunction(performance.someFunc3);
+
+                this.clock.uninstall();
+
+                delete Performance.prototype.someFunc1;
+                delete Performance.prototype.someFunc2;
+                delete Performance.prototype.someFunc3;
+            });
         }
 
         if (Object.getPrototypeOf(global)) {


### PR DESCRIPTION
## Related issue
https://github.com/sinonjs/lolex/issues/136

## Why

performance.mark method is not an own property.

```javascript
console.log(Object.getOwnPropertyNames(performance)) // [], it's empty.
```

It belongs to Performance.prototype.
Because all properties in performance._\_proto__ are not clock.performance's own properties, 

```javascript
clock.performance = Object.create(global.performance);
```
they couldn't pass the following conditional statements.

```javascript
target[method] = function () {
    return clock[method].apply(clock, arguments);
};

for (prop in clock[method]) {
    if (clock[method].hasOwnProperty(prop)) {
        target[method][prop] = clock[method][prop];
    }
}
```