### PR TITLE
handle negative infinity timeout

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -44,6 +44,18 @@ function withGlobal(_global) {
     var NativeDate = Date;
     var uniqueTimerId = 1;
 
+    function isNumberFinite(num) {
+        if (Number.isFinite) {
+            return Number.isFinite(num);
+        }
+
+        if (typeof num !== "number") {
+            return false;
+        }
+
+        return isFinite(num);
+    }
+
     /**
      * Parse strings like "01:10:00" (meaning 1 hour, 10 minutes, 0 seconds) into
      * number of milliseconds. This is used to support human-readable strings passed
@@ -201,6 +213,9 @@ function withGlobal(_global) {
         timer.type = timer.immediate ? "Immediate" : "Timeout";
 
         if (timer.hasOwnProperty("delay")) {
+            if (!isNumberFinite(timer.delay)) {
+                timer.delay = 0;
+            }
             timer.delay = timer.delay > maxTimeout ? 1 : timer.delay;
             timer.delay = Math.max(0, timer.delay);
         }

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -280,6 +280,20 @@ describe("lolex", function () {
             this.clock.tick(61);
             assert.equals(callbackCalled, true);
         });
+        it("handles Infinity and negative Infinity correctly", function () {
+            var calls = [];
+            this.clock.setTimeout(function () {
+                calls.push("NaN");
+            }, NaN);
+            this.clock.setTimeout(function () {
+                calls.push("Infinity");
+            }, Number.POSITIVE_INFINITY);
+            this.clock.setTimeout(function () {
+                calls.push("-Infinity");
+            }, Number.NEGATIVE_INFINITY);
+            this.clock.runAll();
+            assert.equals(calls, ["NaN", "Infinity", "-Infinity"]);
+        });
     });
 
     describe("setImmediate", function () {


### PR DESCRIPTION
See this issue in Jest, with links to spec: https://github.com/facebook/jest/issues/5960. Without changing the implementation of Lolex, Jest test suite breaks when attempting to use it