### PR TITLE
Access `Performance` via `_global`

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -733,7 +733,7 @@ function withGlobal(_global) {
         if (performancePresent) {
             clock.performance = Object.create(_global.performance);
 
-            var proto = Performance.prototype;
+            var proto = _global.Performance.prototype;
 
             Object
                 .getOwnPropertyNames(_global.Performance.prototype)


### PR DESCRIPTION
Ref #167, but it's not enough. With this change, Jest fails with an internal JSDOM error...

![image](https://user-images.githubusercontent.com/1404810/39768976-1a85b9ec-52eb-11e8-8187-424df21d48f0.png)

Looks like the same error as the one from IE in #167, so fixing that will probably fix Jest as well