### PR TITLE
feat: respect loopLimit in runMicrotasks

### DIFF
--- a/lolex.js
+++ b/lolex.js
@@ -200,9 +200,16 @@ function withGlobal(_global) {
         if (!clock.jobs) {
             return;
         }
+        // note, we can't check clock.jobs.length for > loopLimit here since jobs 
+        // may be enqueued while running existing jobs
+        var jobsRan = 0;
         for (var i = 0; i < clock.jobs.length; i++) {
             var job = clock.jobs[i];
             job.func.apply(null, job.args);
+            jobsRan++;
+            if (clock.loopLimit && jobsRan > clock.loopLimit) {
+                throw new Error("Aborting after running " + clock.loopLimit + " timers, assuming an infinite loop!");
+            }
         }
         clock.jobs = [];
     }

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -198,9 +198,16 @@ function withGlobal(_global) {
         if (!clock.jobs) {
             return;
         }
+        // note, we can't check clock.jobs.length for > loopLimit here since jobs 
+        // may be enqueued while running existing jobs
+        var jobsRan = 0;
         for (var i = 0; i < clock.jobs.length; i++) {
             var job = clock.jobs[i];
             job.func.apply(null, job.args);
+            jobsRan++;
+            if (clock.loopLimit && jobsRan > clock.loopLimit) {
+                throw new Error("Aborting after running " + clock.loopLimit + " timers, assuming an infinite loop!");
+            }
         }
         clock.jobs = [];
     }

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -2321,6 +2321,36 @@ describe("lolex", function () {
                 assert(called);
             });
 
+            it("respects loopLimit from below in runMicrotasks", function () {
+                var clock = lolex.createClock(0, 100);
+                for (var i = 0; i < 99; i++) {
+                    // eslint-disable-next-line no-loop-func,ie11/no-loop-func
+                    clock.nextTick(function () {
+                        i--;
+                    });
+                }
+                clock.runMicrotasks();
+                assert.equals(i, 0);
+            });
+
+            it("respects loopLimit from above in runMicrotasks", function () {
+                var clock = lolex.createClock(0, 100);
+                for (var i = 0; i < 120; i++) {
+                    // eslint-disable-next-line ie11/no-loop-func
+                    clock.nextTick(function () { });
+                }
+                assert.exception(function () { clock.runMicrotasks(); });
+            });
+
+
+            it("detects infinite nextTick cycles", function () {
+                var clock = lolex.createClock(0, 1000);
+                clock.nextTick(function repeat() {
+                    clock.nextTick(repeat);
+                });
+                assert.exception(function () { clock.runMicrotasks(); });
+            });
+
             it("runs with timers - and before them", function () {
                 var clock = lolex.createClock();
                 var last = "";


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix issue https://github.com/sinonjs/lolex/issues/147 by taking loopLimit into account in `runMicrotasks`.

Note that in particular the limit isn't enforced compoundly in `runAll` - rather _either_ the number of timers _or_ the number of microtasks reaches the loopLimit. The alternative was to count them towards the limit together but that seemed undesirable since there might be a lot of miroticks between macroticks and I didn't want to risk a breaking change.