### PR TITLE
chore: use `prepublishOnly` instead of `prepublish`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-cloud": "mochify --wd",
     "test": "npm run lint && npm run test-node && npm run test-headless",
     "bundle": "browserify -s lolex -o lolex.js src/lolex-src.js",
-    "prepublish": "npm run bundle",
+    "prepublishOnly": "npm run bundle",
     "precommit": "run-p lint test-node"
   },
   "lint-staged": {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

This avoids running `bundle` on `npm install`, meaning it's less likely to be included in PRs. It also removes the warning: 
![image](https://user-images.githubusercontent.com/1404810/39965601-80caea88-569c-11e8-8e0d-99f99eb7e19e.png)

https://docs.npmjs.com/misc/scripts#prepublish-and-prepare