### PR TITLE
 Access Date on `_global`

### DIFF
--- a/integration-test/lolex-integration-test.js
+++ b/integration-test/lolex-integration-test.js
@@ -48,4 +48,14 @@ describe("withGlobal", function () {
 
         clock.uninstall();
     });
+
+    it("Date is instanceof itself", function () {
+        assert(new jsdomGlobal.Date() instanceof jsdomGlobal.Date);
+
+        var clock = withGlobal.install({target: jsdomGlobal, toFake: timers});
+
+        assert(new jsdomGlobal.Date() instanceof jsdomGlobal.Date);
+
+        clock.uninstall();
+    });
 });

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -41,7 +41,7 @@ function withGlobal(_global) {
 
     _global.clearTimeout(timeoutResult);
 
-    var NativeDate = Date;
+    var NativeDate = _global.Date;
     var uniqueTimerId = 1;
 
     function isNumberFinite(num) {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
This was discovered by @mjesun when trying to apply a version of Jest with Lolex at Facebook.

I'm not sure what the solution should be. Our idea was to just assign the `prototype`, but it is already copied