### PR TITLE
fix clock.timers initialization from array to object

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -362,7 +362,7 @@ function withGlobal(_global) {
         }
 
         if (!clock.timers) {
-            clock.timers = [];
+            clock.timers = {};
         }
 
         // in Node, timerId is an object with .ref()/.unref(), and


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

`clock.timers` is used everywhere as an object and initializing in all other places as an object. So here it's a bug that is not affecting the functionality because of nature of JS but confuses the source readers