### PR TITLE
add advanceTimeFactor option and test case

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -461,8 +461,8 @@ function withGlobal(_global) {
         target[method].clock = clock;
     }
 
-    function doIntervalTick(clock, advanceTimeDelta) {
-        clock.tick(advanceTimeDelta);
+    function doIntervalTick(clock, advanceTimeAmount) {
+        clock.tick(advanceTimeAmount);
     }
 
     var timers = {
@@ -797,6 +797,7 @@ function withGlobal(_global) {
      * @param config.loopLimit {number} the maximum number of timers that will be run when calling runAll()
      * @param config.shouldAdvanceTime {Boolean} tells lolex to increment mocked time automatically (default false)
      * @param config.advanceTimeDelta {Number} increment mocked time every <<advanceTimeDelta>> ms (default: 20ms)
+     * @param config.advanceTimeFactor {Number} increment mocked time with <<advanceTimeFactor>> times (default: 1)
      */
     function install(config) {
         if ( arguments.length > 1 || config instanceof Date || Array.isArray(config) || typeof config === "number") {
@@ -806,6 +807,7 @@ function withGlobal(_global) {
         config = typeof config !== "undefined" ? config : {};
         config.shouldAdvanceTime = config.shouldAdvanceTime || false;
         config.advanceTimeDelta = config.advanceTimeDelta || 20;
+        config.advanceTimeFactor = config.advanceTimeFactor || 1;
 
         var i, l;
         var target = config.target || _global;
@@ -833,7 +835,8 @@ function withGlobal(_global) {
                 }
             } else {
                 if (clock.methods[i] === "setInterval" && config.shouldAdvanceTime === true) {
-                    var intervalTick = doIntervalTick.bind(null, clock, config.advanceTimeDelta);
+                    var advanceTimeAmount = config.advanceTimeDelta * config.advanceTimeFactor;
+                    var intervalTick = doIntervalTick.bind(null, clock, advanceTimeAmount);
                     var intervalId = target[clock.methods[i]](
                         intervalTick,
                         config.advanceTimeDelta);

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -2057,9 +2057,9 @@ describe("lolex", function () {
 
             nativeSetTimeout(function () {
                 var timeDifference = Date.now() - timeoutStarted;
-                var nativeTimeDiffernce = nativeDateNow() - timeoutStarted;
+                var nativeTimeDifference = nativeDateNow() - timeoutStarted;
                 assert.same(timeDifference, testDelta * testFactor);
-                assert.isTrue(Math.abs(nativeTimeDiffernce - testDelay) <= 5); // 0~5 admissible error
+                assert.isTrue(Math.abs(nativeTimeDifference - testDelay) <= 5); // 0~5 admissible error
                 clock.uninstall();
                 done();
             }, testDelay);

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -2043,6 +2043,27 @@ describe("lolex", function () {
                 }
             }, interval);
         });
+
+        it("should test advanceTimeFactor", function (done) {
+            var testDelay = 29;
+            var testDelta = 20;
+            var testFactor = 3;
+            var nativeSetTimeout = setTimeout;
+            var nativeDateNow = Date.now;
+            var clock = lolex.install({
+                now: Date.now(), shouldAdvanceTime: true, advanceTimeDelta: testDelta, advanceTimeFactor: testFactor
+            });
+            var timeoutStarted = Date.now();
+
+            nativeSetTimeout(function () {
+                var timeDifference = Date.now() - timeoutStarted;
+                var nativeTimeDiffernce = nativeDateNow() - timeoutStarted;
+                assert.same(timeDifference, testDelta * testFactor);
+                assert.isTrue(Math.abs(nativeTimeDiffernce - testDelay) <= 5); // 0~5 admissible error
+                clock.uninstall();
+                done();
+            }, testDelay);
+        });
     });
 
     describe("requestAnimationFrame", function () {


### PR DESCRIPTION
<!--
> give a concise (one or two short sentences) description of what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->
Description: This PR provides a config option `advanceTimeFactor` to use along with the existing `shouldAdvanceTime: true` and `advanceTimeDelta: 20`, in order to make the faked time pass x faster or slower.

<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->
Background: I was intended to build a CMS module (time travelling) for time controlling based on lolex, and I found there is no ability to control the speed of time passing.

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->
Solution: I counted `advanceTimeAmount = advanceTimeDelta * advanceTimeFactor` as arg for the doIntervalTick method called.