### PR TITLE
Fixes ref() & unref() return value on NodeJS

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -245,11 +245,12 @@ function withGlobal(_global) {
         clock.timers[timer.id] = timer;
 
         if (addTimerReturnsObject) {
-            return {
+            var res = {
                 id: timer.id,
-                ref: NOOP,
-                unref: NOOP
+                ref: function () { return res; },
+                unref: function () { return res; }
             };
+            return res;
         }
 
         return timer.id;

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -248,7 +248,8 @@ function withGlobal(_global) {
             var res = {
                 id: timer.id,
                 ref: function () { return res; },
-                unref: function () { return res; }
+                unref: function () { return res; },
+                refresh: function () { return res; }
             };
             return res;
         }

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1774,6 +1774,18 @@ describe("lolex", function () {
             }
         });
 
+        it("global fake setTimeout().refresh() should return timer", function () {
+            this.clock = lolex.install();
+            var stub = sinon.stub();
+
+            if (typeof (setTimeout(NOOP, 0)) === "object") {
+                var to = setTimeout(stub, 1000).refresh();
+                assert.isNumber(to.id);
+                assert.isFunction(to.ref);
+                assert.isFunction(to.refresh);
+            }
+        });
+
         it("replaces global clearTimeout", function () {
             this.clock = lolex.install();
             var stub = sinon.stub();

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1750,6 +1750,30 @@ describe("lolex", function () {
             }
         });
 
+        it("global fake setTimeout().ref() should return timer", function () {
+            this.clock = lolex.install();
+            var stub = sinon.stub();
+
+            if (typeof (setTimeout(NOOP, 0)) === "object") {
+                var to = setTimeout(stub, 1000).ref();
+                assert.isNumber(to.id);
+                assert.isFunction(to.ref);
+                assert.isFunction(to.unref);
+            }
+        });
+
+        it("global fake setTimeout().unref() should return timer", function () {
+            this.clock = lolex.install();
+            var stub = sinon.stub();
+
+            if (typeof (setTimeout(NOOP, 0)) === "object") {
+                var to = setTimeout(stub, 1000).unref();
+                assert.isNumber(to.id);
+                assert.isFunction(to.ref);
+                assert.isFunction(to.unref);
+            }
+        });
+
         it("replaces global clearTimeout", function () {
             this.clock = lolex.install();
             var stub = sinon.stub();


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix issue #191 

According to NodeJS documentation the ref() and unref() return the timer.
https://nodejs.org/dist/latest-v8.x/docs/api/timers.html#timers_timeout_ref

This PR fixes it in lolex. Relevant tests are added.

After fix it prints the correct timer:
```js
const lolex = require("./src/lolex-src");
const clock = lolex.install();

const timer = setTimeout(() => {}, 5000).unref();
console.log(timer);
// Prints: { id: 1, ref: [Function: ref], unref: [Function: unref] }
```
