### PR TITLE
Fix performance replacement on iOS 9.3

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -405,10 +405,7 @@ function withGlobal(_global) {
             } else if (method === "nextTick" && target.process) {
                 target.process.nextTick = clock[installedNextTick];
             } else if (method === "performance") {
-                Object.defineProperty(target, method, {
-                    writeable: false,
-                    value: clock["_" + method]
-                });
+                target[method] = clock["_" + method];
             } else {
                 if (target[method] && target[method].hadOwnProperty) {
                     target[method] = clock["_" + method];
@@ -444,10 +441,7 @@ function withGlobal(_global) {
             var date = mirrorDateProperties(clock[method], target[method]);
             target[method] = date;
         } else if (method === "performance") {
-            Object.defineProperty(target, method, {
-                writeable: false,
-                value: clock[method]
-            });
+            target[method] = clock[method];
         } else {
             target[method] = function () {
                 return clock[method].apply(clock, arguments);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

While trying to run a test suite with fake timer in iOS 9.3, I discovered an issue with lolex: `window.performance` cannot be replaced using `Object.defineProperty` because its descriptor has `configurable: false`. However, assigning a new value works.

Also happens to fix #190.

#### Solution  - optional

I first tried checking on the descriptor `configurable` property which fixed the issue. It turned out that simply replacing the property works as well, but I recalled that `Object.setProperty` was introduced in #169 by @SimenB to fix it in JSDom. However, all tests pass and I'd like to have confirmation by a JSDom expert that this change doesn't re-introduce the issue.

#### Verifying the problem

I can reproduce the issue with the lolex test suite:

```bash
$ node_modules/.bin/mochify --consolify test.html
$ http-server .
```

and then open `http://localhost:8080/test.html` in the iOS 9.3 emulator.

With this fix applied, the test suite passes again.