### PR TITLE
fix(setInterval): parse `timeout` arg to integer

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -544,6 +544,7 @@ function withGlobal(_global) {
             });
         };
         clock.setInterval = function setInterval(func, timeout) {
+            timeout = parseInt(timeout);
             return addTimer(clock, {
                 func: func,
                 args: Array.prototype.slice.call(arguments, 2),

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -544,7 +544,7 @@ function withGlobal(_global) {
             });
         };
         clock.setInterval = function setInterval(func, timeout) {
-            timeout = parseInt(timeout);
+            timeout = parseInt(timeout, 10);
             return addTimer(clock, {
                 func: func,
                 args: Array.prototype.slice.call(arguments, 2),

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -602,6 +602,15 @@ describe("lolex", function () {
             assert.equals(spy.callCount, 38);
         });
 
+        it("fires timer in intervals of '13'", function () {
+            var spy = sinon.spy();
+            this.clock.setInterval(spy, "13");
+
+            this.clock.tick(500);
+
+            assert.equals(spy.callCount, 38);
+        });
+
         it("fires timers in correct order", function () {
             var spy13 = sinon.spy();
             var spy10 = sinon.spy();


### PR DESCRIPTION
#### Purpose (TL;DR)

Fix issue #201 by always parsing the `timeout` argument of `setInterval` to an integer value, so that strings are possible.

#### Background

See Description in #201 

#### Solution

As suggested by @fatso83, the argument is now parsed to an integer value (`parseInt()`).
There is also a test proving that a string input works.