### PR TITLE
Fix issue 200: performance.mark triggers TypeError

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -754,7 +754,7 @@ function withGlobal(_global) {
                     .getOwnPropertyNames(proto)
                     .forEach(function (name) {
                         if (Object.getOwnPropertyDescriptor(proto, name).writable) {
-                            clock.performance[name] = proto[name];
+                            clock.performance[name] = NOOP;
                         }
                     });
             }

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1934,6 +1934,14 @@ describe("lolex", function () {
                 delete Performance.prototype.someFunc2;
                 delete Performance.prototype.someFunc3;
             });
+
+            it("should not throw an error on calling performance.mark", function () {
+                this.clock = lolex.install();
+                assert.isFunction(global.performance.mark);
+                refute.exception(function () {
+                    global.performance.mark("a name");
+                });
+            });
         }
 
         if (Object.getPrototypeOf(global)) {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1902,13 +1902,13 @@ describe("lolex", function () {
                 assert.same(performance.now, oldNow);
             });
 
-            it("keeps the performance.mark method after being installed (#136)", function () {
+            it("should let performance.mark still be a method after being installed (#136)", function () {
                 var originalMark = Performance.prototype.mark;
                 Performance.prototype.mark = function () {};
 
                 assert.same(global.performance.mark, Performance.prototype.mark);
                 this.clock = lolex.install();
-                assert.same(global.performance.mark, Performance.prototype.mark);
+                assert.isFunction(global.performance.mark);
                 this.clock.uninstall();
                 assert.same(global.performance.mark, Performance.prototype.mark);
 

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1903,16 +1903,8 @@ describe("lolex", function () {
             });
 
             it("should let performance.mark still be a method after being installed (#136)", function () {
-                var originalMark = Performance.prototype.mark;
-                Performance.prototype.mark = function () {};
-
-                assert.same(global.performance.mark, Performance.prototype.mark);
                 this.clock = lolex.install();
                 assert.isFunction(global.performance.mark);
-                this.clock.uninstall();
-                assert.same(global.performance.mark, Performance.prototype.mark);
-
-                Performance.prototype.mark = originalMark;
             });
 
             it("should not alter the global performance properties and methods", function () {


### PR DESCRIPTION
Fixes issue #200 by overriding methods on window.performance

Could not see any reason why to keep the initial implementation delegated to the original
object, so overrode them with no-ops. Input on why this might not be the right way
to deal with this?