### PR TITLE
Fix cloud tests for IE and Safari :hankey:

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -32,7 +32,7 @@ function withGlobal(_global) {
     var hrtimePresent = (_global.process && typeof _global.process.hrtime === "function");
     var nextTickPresent = (_global.process && typeof _global.process.nextTick === "function");
     var performancePresent = (_global.performance && typeof _global.performance.now === "function");
-    var performanceConstructorExists = (_global.Performance && typeof _global.Performance === "function");
+    var hasPerformancePrototype = (_global.Performance && (typeof _global.Performance).match(/^(function|object)$/));
     var requestAnimationFramePresent = (
         _global.requestAnimationFrame && typeof _global.requestAnimationFrame === "function"
     );
@@ -746,8 +746,7 @@ function withGlobal(_global) {
         if (performancePresent) {
             clock.performance = Object.create(_global.performance);
 
-
-            if (performanceConstructorExists) {
+            if (hasPerformancePrototype) {
                 var proto = _global.Performance.prototype;
 
                 Object
@@ -763,6 +762,7 @@ function withGlobal(_global) {
                 return clock.hrNow;
             };
         }
+
         if (hrtimePresent) {
             clock.hrtime = function (prev) {
                 if (Array.isArray(prev)) {

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -744,7 +744,7 @@ function withGlobal(_global) {
         };
 
         if (performancePresent) {
-            clock.performance = Object.create(_global.performance);
+            clock.performance = Object.create(null);
 
             if (hasPerformancePrototype) {
                 var proto = _global.Performance.prototype;
@@ -752,9 +752,7 @@ function withGlobal(_global) {
                 Object
                     .getOwnPropertyNames(proto)
                     .forEach(function (name) {
-                        if (Object.getOwnPropertyDescriptor(proto, name).writable) {
-                            clock.performance[name] = NOOP;
-                        }
+                        clock.performance[name] = NOOP;
                     });
             }
 


### PR DESCRIPTION
The changes introduced for 2.7.3 did not break anything, but it introduced a new test that showed
bugs in the existing implementation by actually running `performance.mark()`.

Also, trying to run performance.mark failed on Safari 9, as it has `performance.now`, but
not `performance.mark`. We therefore needed an additional guard before those tests.

We didn't see the fail until merging to master due to pull requests not running the Sauce Labs
tests, and me being too forgetful and impatient to wait for the tests 😀

The changes can be split into two

- changes in the test code to avoid running a test in Safari 9
- changes in the library that deals with IE 10 and IE 11

The prototype for `Performance` in Internet Explorer is not a function like
everywhere else, so we needed to expand the test for object types.