### PR TITLE
Add an error when creating a clock with no Date object

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -512,6 +512,11 @@ function withGlobal(_global) {
         start = start || 0;
         loopLimit = loopLimit || 1000;
 
+        if (NativeDate === undefined) {
+            throw new Error("The global scope doesn't have a `Date` object"
+                + " (see https://github.com/sinonjs/sinon/issues/1852#issuecomment-419622780)");
+        }
+
         var clock = {
             now: getEpoch(start),
             hrNow: 0,

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -103,6 +103,17 @@ describe("issue #67", function () {
     });
 });
 
+describe("issue sinon#1852", function () {
+    it("throws when creating a clock and global has no Date", function () {
+        var clock = lolex.withGlobal({
+            setTimeout: function () {},
+            clearTimeout: function () {}
+        });
+        assert.exception(function () { clock.createClock(); });
+        assert.exception(function () { clock.install(); });
+    });
+});
+
 describe("lolex", function () {
 
     describe("setTimeout", function () {


### PR DESCRIPTION
#### Purpose

Improve [sinon#1852](https://github.com/sinonjs/sinon/issues/1852) issue by adding an explicit error message.


#### Background

When using `webpack` and `jsdom` together, the global context doesn't have a `Date` object and `lolex` will fail with a really confusing error: `TypeError: Cannot read property 'now' of undefined`.

This problem is easily triggered when using `sinon.useFakeTimers` (which relies on `lolex`) in this setup.


#### Solution

This PR adds an explicit exception when no `Date` are present in the global context.

The message contains a link to @mroderick's comment that explains how to get around the problem. (Maybe this would be better as a wiki page?)

The check is placed in `createClock` (which means it's triggered by `install` as well) instead of right when `NativeDate` is initialised so it doesn't crash right away (as `withGlobal` is called when the module is initialised).