### PR TITLE
fix: runToLast should respect current time

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -720,7 +720,7 @@ function withGlobal(_global) {
                 return clock.now;
             }
 
-            return clock.tick(timer.callAt);
+            return clock.tick(timer.callAt - clock.now);
         };
 
         clock.reset = function reset() {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1225,21 +1225,17 @@ describe("lolex", function () {
         it("should support clocks with start time", function () {
             var startingPoint = new Date("2018-01-01").getTime();
             this.clock = lolex.createClock(startingPoint);
-            var runOrder = [];
             var that = this;
+            var invocations = 0;
 
             this.clock.setTimeout(function cb() {
-                runOrder.push("mock1");
-                that.clock.setTimeout(cb, 49);
+                invocations++;
+                that.clock.setTimeout(cb, 50);
             }, 50);
-
-            this.clock.setTimeout(function cb() {
-                runOrder.push("mock2");
-            }, 100);
 
             this.clock.runToLast();
 
-            assert.equals(runOrder, ["mock1", "mock1", "mock2"]);
+            assert.equals(invocations, 1);
         });
 
     });

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1222,6 +1222,26 @@ describe("lolex", function () {
             assert.isTrue(spy.called);
         });
 
+        it("should support clocks with start time", function () {
+            var startingPoint = new Date("2018-01-01").getTime();
+            this.clock = lolex.createClock(startingPoint);
+            var runOrder = [];
+            var that = this;
+
+            this.clock.setTimeout(function cb() {
+                runOrder.push("mock1");
+                that.clock.setTimeout(cb, 49);
+            }, 50);
+
+            this.clock.setTimeout(function cb() {
+                runOrder.push("mock2");
+            }, 100);
+
+            this.clock.runToLast();
+
+            assert.equals(runOrder, ["mock1", "mock1", "mock2"]);
+        });
+
     });
 
     describe("clearTimeout", function () {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -1223,8 +1223,7 @@ describe("lolex", function () {
         });
 
         it("should support clocks with start time", function () {
-            var startingPoint = new Date("2018-01-01").getTime();
-            this.clock = lolex.createClock(startingPoint);
+            this.clock = lolex.createClock(200);
             var that = this;
             var invocations = 0;
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Without the code change, the added test makes node hangs forever until it runs out of memory.

#### Background (Problem in detail)  - optional
`clock.tick` expect the argument to be how many millis it should tick. Currently, we pass it the timestamp of when it should be done ticking.

https://github.com/sinonjs/lolex/blob/1278eaade7da311d203fc6c33f67f85c828a09f2/src/lolex-src.js#L723

I don't understand how no-one hit this bug for 2.5 years... It's been that way since the original implementation: #50.

#### Solution

Subtract the current time on the clock before calling `tick`. The first thing tick does is add it back, so it knows when to stop.

https://github.com/sinonjs/lolex/blob/1278eaade7da311d203fc6c33f67f85c828a09f2/src/lolex-src.js#L603

We might want a `tickTo` method? Implementation would be `this.tick(to - clock.now)`, so maybe not valuable.