### PR TITLE
Make releasing a new  version a 2 step process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,39 +2,13 @@
 
 You'll need a working installation of [git-extras](https://github.com/tj/git-extras) for this.
 
-## Update Changelog.txt
-
-Compile interesting highlights from [`git changelog`](https://github.com/tj/git-extras/blob/master/Commands.md#git-changelog) into Changelog.md
-
-    git changelog --no-merges
-
-## Update AUTHORS
-
-    git authors --list > AUTHORS
-
-## Build a new bundle and commit changed files
-
-    npm run bundle
-    git add lolex.js AUTHORS History.md
-    git commit -m "Prepare for new release"
-
 ## Create a new version
 
 ```
-$ npm version x.y.z
+$ npm version x.y.z # or npm version [patch|minor|major]
 ```
 
-Updates package.json and creates a new tag.
-
-## Create a new PR
-The `master` branch is protected.
-You can merge it yourself.
-
-## Push new commits and tags
-> Assuming that `origin` points to `github.com/sinonjs/lolex`
-```
-git push --follow-tags origin
-```
+Runs the tests, builds a changelog and the authors file, updates package.json, creates a new tag and pushes the tag and its commits to the sinon repo.
 
 ## Publish to NPM
 
@@ -43,6 +17,7 @@ $ npm publish
 ```
 
 ## Create a GitHub release
+
 Create a GitHub release where you highlight
 interesting additions from the changelog.
 Just add a release notes to [the existing tag](https://github.com/sinonjs/lolex/tags).

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "test": "npm run lint && npm run test-node && npm run test-headless",
     "bundle": "browserify -s lolex -o lolex.js src/lolex-src.js",
     "prepublishOnly": "npm run bundle",
-    "precommit": "run-p lint test-node"
+    "precommit": "run-p lint test-node",
+    "preversion": "./scripts/preversion.sh",
+    "version": "./scripts/version.sh",
+    "postversion": "./scripts/postversion.sh"
   },
   "lint-staged": {
     "*.js": "eslint"

--- a/scripts/postversion.sh
+++ b/scripts/postversion.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR > /dev/null
+
+# check that that origin points to the sinonjs/lolex repo
+git remote -v | grep 'origin.*sinonjs/lolex.*push' > /dev/null
+
+if [[ $? != 0 ]]; then
+    echo "'origin' doesn't point to the sinonjs/lolex repo. Fix tag push manually!"
+    exit 1
+fi
+
+git push --follow-tags origin

--- a/scripts/preversion.sh
+++ b/scripts/preversion.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR > /dev/null
+
+npm test # lints and tests

--- a/scripts/preversion.sh
+++ b/scripts/preversion.sh
@@ -3,4 +3,13 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR > /dev/null
 
+export SAUCE_USERNAME=sinonjs
+
+if [[ ! -v SAUCE_ACCESS_KEY ]]; then
+    echo 'SAUCE_ACCESS_KEY has not been exported and made available for test `test-cloud` script!'
+    exit 1
+fi
+
 npm test # lints and tests
+
+npm run test-cloud # should not take more than approx 25 seconds

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/.." > /dev/null
+
+PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
+
+echo 'Updating History.md'
+git changelog --no-merges
+git add History.md
+
+echo 'Updating AUTHORS'
+git authors --list > AUTHORS
+git add AUTHORS
+
+echo 'Build bundle'
+npm run bundle
+git add lolex.js
+
+git commit -m "Updated release files for $PACKAGE_VERSION"


### PR DESCRIPTION
# Purpose
Releasing is tedious. This is faster.
Simplifies the release process into `npm version patch && npm publish`

# Details
One point that might be worth noting (changing?) is that at no point
are we running the cloud tests. This is only usually done on the master
branch, but we have had times where the maintainer has been a bit too
quick and haven't waited for the `master` branch to build before
releasing a new version.

Should we include a `postversion` step where we run the `test-cloud`
script? All maintainers should by now have access to the sauce labs
credentials.