### PR TITLE
Introduce nanosecond precision ticks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -218,9 +218,6 @@ milliseconds to advance the clock by or a human-readable string. Valid string
 formats are `"08"` for eight seconds, `"01:00"` for one minute and `"02:34:10"`
 for two hours, 34 minutes and ten seconds.
 
-`time` may be negative, which causes the clock to change but won't fire any
-callbacks.
-
 ### `clock.next()`
 
 Advances the clock to the the moment of the first scheduled timer, firing it.

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -626,6 +626,10 @@ function withGlobal(_global) {
             var nanosTotal = nanos + remainder;
             var tickTo = clock.now + ms;
 
+            if (msFloat < 0) {
+                throw new TypeError("Negative ticks are not supported");
+            }
+
             // adjust for positive overflow
             if (nanosTotal >= 1e6) {
                 tickTo += 1;

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -91,15 +91,19 @@ function withGlobal(_global) {
     }
 
     /**
+     * Get the decimal part of the millisecond value as nanoseconds
+     *
      * @param {Number} msFloat the number of milliseconds
-     * @returns the remaining number of nanoseconds in the range [0,1e6)
+     * @returns {Number} an integer number of nanoseconds in the range [0,1e6)
      *
      * Example: nanoRemainer(123.456789) -> 456789
      */
     function nanoRemainder(msFloat) {
         var modulo = 1e6;
         var remainder = (msFloat * 1e6) % modulo;
-        return remainder < 0 ? remainder + modulo : remainder;
+        var positiveRemainder = remainder < 0 ? remainder + modulo : remainder;
+
+        return Math.floor(positiveRemainder);
     }
 
     /**

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -117,39 +117,41 @@ describe("issue sinon#1852", function () {
 describe("issue #207 - nanosecond round-off errors on high-res timer", function () {
     var clock;
 
-    afterEach(function() {
+    afterEach(function () {
         clock.uninstall();
     });
 
-    it("should not round off nanosecond arithmetic on hrtime - case 1", function () {
-        clock = lolex.install()
+    if (hrtimePresent) {
+        it("should not round off nanosecond arithmetic on hrtime - case 1", function () {
+            clock = lolex.install();
 
-        clock.tick(1022.7791)
+            clock.tick(1022.7791);
 
-        var nanos = clock.hrtime([0, 2*1e7])[1];
-        assert.equals(nanos, 2779100);
-    });
-
-    it("should not round off nanosecond arithmetic on hrtime - case 2", function () {
-        clock = lolex.install({
-            now: new Date("2018-09-12T08:58:33.742000000Z").getTime(),
-            toFake: ["hrtime"]
+            var nanos = clock.hrtime([0, 2 * 1e7])[1];
+            assert.equals(nanos, 2779100);
         });
-        var start = clock.hrtime();
-        clock.tick(123.493);
 
-        var nanos = clock.hrtime(start)[1];
-        assert.equals(nanos, 123493000);
-    });
+        it("should not round off nanosecond arithmetic on hrtime - case 2", function () {
+            clock = lolex.install({
+                now: new Date("2018-09-12T08:58:33.742000000Z").getTime(),
+                toFake: ["hrtime"]
+            });
+            var start = clock.hrtime();
+            clock.tick(123.493);
 
-    it("should always set 'now' to an integer value when ticking with sub-millisecond precision", function (){
+            var nanos = clock.hrtime(start)[1];
+            assert.equals(nanos, 123493000);
+        });
+    }
+
+    it("should always set 'now' to an integer value when ticking with sub-millisecond precision", function () {
         clock = lolex.install();
         clock.tick(2.993);
 
         assert.equals(clock.now, 2);
     });
 
-    it("should adjust adjust the 'now' value when the nano-remainder overflows", function (){
+    it("should adjust adjust the 'now' value when the nano-remainder overflows", function () {
         clock = lolex.install();
         clock.tick(0.993);
         clock.tick(.5);
@@ -157,23 +159,23 @@ describe("issue #207 - nanosecond round-off errors on high-res timer", function 
         assert.equals(clock.now, 1);
     });
 
-    it("should floor negative now values", function (){
+    it("should floor negative now values", function () {
         clock = lolex.install({now: -1.2});
 
         assert.equals(clock.now, -2);
     });
 
-    it("should floor start times", function (){
+    it("should floor start times", function () {
         clock = lolex.install({now: 1.2});
         assert.equals(clock.now, 1);
     });
 
-    it("should floor negative start times", function (){
+    it("should floor negative start times", function () {
         clock = lolex.install({now: -1.2});
         assert.equals(clock.now, -2);
     });
 
-    it("should handle ticks on the negative side of the Epoch", function (){
+    it("should handle ticks on the negative side of the Epoch", function () {
         clock = lolex.install({now: -2});
         clock.tick(0.8); // -1.2
         clock.tick(0.5); // -0.7
@@ -181,7 +183,7 @@ describe("issue #207 - nanosecond round-off errors on high-res timer", function 
         assert.equals(clock.now, -1);
     });
 
-    it("should handle multiple non-integer ticks", function (){
+    it("should handle multiple non-integer ticks", function () {
         clock = lolex.install({now: -2});
         clock.tick(1.1); // -0.9
         clock.tick(0.5);
@@ -1402,9 +1404,11 @@ describe("lolex", function () {
         });
 
         it("resets hrTime - issue #206", function () {
+            if (!hrtimePresent) { this.skip(); }
+
             var clock = lolex.createClock();
             clock.tick(100);
-            assert.equals(clock.hrtime(), [0, 100*1e6]);
+            assert.equals(clock.hrtime(), [0, 100 * 1e6]);
             clock.reset();
             assert.equals(clock.hrtime(), [0, 0]);
         });
@@ -2370,314 +2374,325 @@ describe("lolex", function () {
         });
     });
 
-    if (performanceNowPresent) {
-        describe("performance.now()", function () {
-            it("should start at 0", function () {
-                var clock = lolex.createClock(1001);
+    describe("performance.now()", function () {
+
+        before(function () {
+            if (!performanceNowPresent) { this.skip(); }
+        });
+
+        it("should start at 0", function () {
+            var clock = lolex.createClock(1001);
+            var result = clock.performance.now();
+            assert.same(result, 0);
+        });
+
+        it("should run along with clock.tick", function () {
+            var clock = lolex.createClock(0);
+            clock.tick(5001);
+            var result = clock.performance.now();
+            assert.same(result, 5001);
+        });
+
+        it("should listen to multiple ticks in performance.now", function () {
+            var clock = lolex.createClock(0);
+            for (var i = 0; i < 10; i++) {
+                var next = clock.performance.now();
+                assert.same(next, 1000 * i);
+                clock.tick(1000);
+            }
+        });
+
+        it("should run with ticks with timers set", function () {
+            var clock = lolex.createClock(0);
+            clock.setTimeout(function () {
                 var result = clock.performance.now();
-                assert.same(result, 0);
-            });
-
-            it("should run along with clock.tick", function () {
-                var clock = lolex.createClock(0);
-                clock.tick(5001);
-                var result = clock.performance.now();
-                assert.same(result, 5001);
-            });
-
-            it("should listen to multiple ticks in performance.now", function () {
-                var clock = lolex.createClock(0);
-                for (var i = 0; i < 10; i++) {
-                    var next = clock.performance.now();
-                    assert.same(next, 1000 * i);
-                    clock.tick(1000);
-                }
-            });
-
-            it("should run with ticks with timers set", function () {
-                var clock = lolex.createClock(0);
-                clock.setTimeout(function () {
-                    var result = clock.performance.now();
-                    assert.same(result, 2500);
-                }, 2500);
-                clock.tick(5000);
-            });
-
+                assert.same(result, 2500);
+            }, 2500);
+            clock.tick(5000);
         });
-    }
-    if (hrtimePresent) {
-        describe("process.hrtime()", function () {
-            afterEach(function () {
-                if (this.clock) {
-                    this.clock.uninstall();
-                }
-            });
 
-            it("should start at 0", function () {
-                var clock = lolex.createClock(1001);
-                var result = clock.hrtime();
-                assert.same(result[0], 0);
-                assert.same(result[1], 0);
-            });
+    });
 
-            it("should run along with clock.tick", function () {
-                var clock = lolex.createClock(0);
-                clock.tick(5001);
-                var prev = clock.hrtime();
-                clock.tick(5001);
+    describe("process.hrtime()", function () {
+
+        before(function () {
+            if (!hrtimePresent) { this.skip(); }
+        });
+
+        afterEach(function () {
+            if (this.clock) {
+                this.clock.uninstall();
+            }
+        });
+
+        it("should start at 0", function () {
+            var clock = lolex.createClock(1001);
+            var result = clock.hrtime();
+            assert.same(result[0], 0);
+            assert.same(result[1], 0);
+        });
+
+        it("should run along with clock.tick", function () {
+            var clock = lolex.createClock(0);
+            clock.tick(5001);
+            var prev = clock.hrtime();
+            clock.tick(5001);
+            var result = clock.hrtime(prev);
+            assert.same(result[0], 5);
+            assert.same(result[1], 1000000);
+        });
+
+        it("should run along with clock.tick when timers set", function () {
+            var clock = lolex.createClock(0);
+            var prev = clock.hrtime();
+            clock.setTimeout(function () {
                 var result = clock.hrtime(prev);
-                assert.same(result[0], 5);
-                assert.same(result[1], 1000000);
-            });
-
-            it("should run along with clock.tick when timers set", function () {
-                var clock = lolex.createClock(0);
-                var prev = clock.hrtime();
-                clock.setTimeout(function () {
-                    var result = clock.hrtime(prev);
-                    assert.same(result[0], 2);
-                    assert.same(result[1], 500000000);
-                }, 2500);
-                clock.tick(5000);
-            });
-
-            it("should not move with setSystemTime", function () {
-                var clock = lolex.createClock(0);
-                var prev = clock.hrtime();
-                clock.setSystemTime(50000);
-                var result = clock.hrtime(prev);
-                assert.same(result[0], 0);
-                assert.same(result[1], 0);
-            });
-
-            it("should move with timeouts", function () {
-                var clock = lolex.createClock();
-                var result = clock.hrtime();
-                assert.same(result[0], 0);
-                assert.same(result[1], 0);
-                clock.setTimeout(function () {}, 1000);
-                clock.runAll();
-                result = clock.hrtime();
-                assert.same(result[0], 1);
-                assert.same(result[1], 0);
-            });
-
-            it("should handle floating point", function () {
-                var clock = lolex.createClock();
-                clock.tick(1022.7791);
-                var result = clock.hrtime([0, 20000000]);
-
-                assert.equals(result, [1, 2779100]);
-            });
+                assert.same(result[0], 2);
+                assert.same(result[1], 500000000);
+            }, 2500);
+            clock.tick(5000);
         });
-    }
-    if (nextTickPresent) {
-        describe("microtask semantics", function () {
-            it("runs without timers", function () {
-                var clock = lolex.createClock();
-                var called = false;
-                clock.nextTick(function () {
-                    called = true;
-                });
-                clock.runAll();
-                assert(called);
-            });
 
-            it("runs when runMicrotasks is called on the clock", function () {
-                var clock = lolex.createClock();
-                var called = false;
-                clock.nextTick(function () {
-                    called = true;
-                });
-                clock.runMicrotasks();
-                assert(called);
-            });
-
-            it("respects loopLimit from below in runMicrotasks", function () {
-                var clock = lolex.createClock(0, 100);
-                for (var i = 0; i < 99; i++) {
-                    // eslint-disable-next-line no-loop-func,ie11/no-loop-func
-                    clock.nextTick(function () {
-                        i--;
-                    });
-                }
-                clock.runMicrotasks();
-                assert.equals(i, 0);
-            });
-
-            it("respects loopLimit from above in runMicrotasks", function () {
-                var clock = lolex.createClock(0, 100);
-                for (var i = 0; i < 120; i++) {
-                    // eslint-disable-next-line ie11/no-loop-func
-                    clock.nextTick(function () { });
-                }
-                assert.exception(function () { clock.runMicrotasks(); });
-            });
-
-
-            it("detects infinite nextTick cycles", function () {
-                var clock = lolex.createClock(0, 1000);
-                clock.nextTick(function repeat() {
-                    clock.nextTick(repeat);
-                });
-                assert.exception(function () { clock.runMicrotasks(); });
-            });
-
-            it("runs with timers - and before them", function () {
-                var clock = lolex.createClock();
-                var last = "";
-                var called = false;
-                clock.nextTick(function () {
-                    called = true;
-                    last = "tick";
-                });
-                clock.setTimeout(function () {
-                    last = "timeout";
-                });
-                clock.runAll();
-                assert(called);
-                assert.equals(last, "timeout");
-            });
-
-            it("runs when time is progressed", function () {
-                var clock = lolex.createClock();
-                var called = false;
-                clock.nextTick(function () {
-                    called = true;
-                });
-                assert(!called);
-                clock.tick(0);
-                assert(called);
-            });
-
-            it("runs between timers", function () {
-                var clock = lolex.createClock();
-                var order = [];
-                clock.setTimeout(function () {
-                    order.push("timer-1");
-                    clock.nextTick(function () {
-                        order.push("tick");
-                    });
-                });
-
-                clock.setTimeout(function () {
-                    order.push("timer-2");
-                });
-                clock.runAll();
-                assert.same(order[0], "timer-1");
-                assert.same(order[1], "tick");
-                assert.same(order[2], "timer-2");
-            });
-
-            it("installs with microticks", function () {
-                var clock = lolex.install({toFake: ["nextTick"]});
-                var called = false;
-                process.nextTick(function () {
-                    called = true;
-                });
-                clock.runAll();
-                assert(called);
-                clock.uninstall();
-            });
-
-            it("installs with microticks and timers in order", function () {
-                var clock = lolex.install({toFake: ["nextTick", "setTimeout"]});
-                var order = [];
-                setTimeout(function () {
-                    order.push("timer-1");
-                    process.nextTick(function () {
-                        order.push("tick");
-                    });
-                });
-                setTimeout(function () {
-                    order.push("timer-2");
-                });
-                clock.runAll();
-                assert.same(order[0], "timer-1");
-                assert.same(order[1], "tick");
-                assert.same(order[2], "timer-2");
-                clock.uninstall();
-            });
-
-            it("uninstalls", function () {
-                var clock = lolex.install({toFake: ["nextTick"]});
-                clock.uninstall();
-                var called = false;
-                process.nextTick(function () {
-                    called = true;
-                });
-                clock.runAll();
-                assert(!called);
-            });
-
-            it("returns an empty list of timers on immediate uninstall", function () {
-                var clock = lolex.install();
-                var timers = clock.uninstall();
-                assert.equals(timers, []);
-            });
-
-
-            it("returns a timer if uninstalling before it's called", function () {
-                var clock = lolex.install();
-                clock.setTimeout(function () {}, 100);
-                var timers = clock.uninstall();
-                assert.equals(timers.length, 1);
-                assert.equals(timers[0].createdAt, clock.now);
-                assert.equals(timers[0].callAt, clock.now + 100);
-                assert(typeof timers[0].id !== "undefined");
-            });
-
-            it("does not return already executed timers on uninstall", function () {
-                var clock = lolex.install();
-                clock.setTimeout(function () {}, 100);
-                clock.setTimeout(function () {}, 200);
-                clock.tick(100);
-                var timers = clock.uninstall();
-                assert.equals(timers.length, 1);
-                assert.equals(timers[0].createdAt, clock.now - 100);
-                assert.equals(timers[0].callAt, clock.now + 100);
-                assert(typeof timers[0].id !== "undefined");
-            });
-
-            it("returns multiple timers on uninstall if created", function () {
-                var clock = lolex.install();
-                for (var i = 0; i < 5; i++) {
-                    // yes, it's silly to create a function in a loop. This is a test, we can live with it
-                    // eslint-disable-next-line ie11/no-loop-func
-                    clock.setTimeout(function () {}, 100 * i);
-                }
-                var timers = clock.uninstall();
-                assert.equals(timers.length, 5);
-                for (i = 0; i < 5; i++) {
-                    assert.equals(timers[i].createdAt, clock.now);
-                    assert.equals(timers[i].callAt, clock.now + 100 * i);
-                }
-                assert(typeof timers[0].id !== "undefined");
-            });
-
-            it("passes arguments when installed - GitHub#122", function () {
-                var clock = lolex.install({toFake: ["nextTick"]});
-                var called = false;
-                process.nextTick(function (value) {
-                    called = value;
-                }, true);
-                clock.runAll();
-                assert(called);
-                clock.uninstall();
-            });
-
-            it("does not install by default - GitHub#126", function (done) {
-                var clock = lolex.install();
-                var spy = sinon.spy(clock, "nextTick");
-                var called = false;
-                process.nextTick(function (value) {
-                    called = value;
-                    assert(called);
-                    assert(!spy.called);
-                    clock.uninstall();
-                    done();
-                }, true);
-            });
+        it("should not move with setSystemTime", function () {
+            var clock = lolex.createClock(0);
+            var prev = clock.hrtime();
+            clock.setSystemTime(50000);
+            var result = clock.hrtime(prev);
+            assert.same(result[0], 0);
+            assert.same(result[1], 0);
         });
-    }
+
+        it("should move with timeouts", function () {
+            var clock = lolex.createClock();
+            var result = clock.hrtime();
+            assert.same(result[0], 0);
+            assert.same(result[1], 0);
+            clock.setTimeout(function () {}, 1000);
+            clock.runAll();
+            result = clock.hrtime();
+            assert.same(result[0], 1);
+            assert.same(result[1], 0);
+        });
+
+        it("should handle floating point", function () {
+            var clock = lolex.createClock();
+            clock.tick(1022.7791);
+            var result = clock.hrtime([0, 20000000]);
+
+            assert.equals(result, [1, 2779100]);
+        });
+    });
+
+    describe("microtask semantics", function () {
+
+        before( function () {
+            if (!nextTickPresent) { this.skip(); }
+        });
+
+        it("runs without timers", function () {
+            var clock = lolex.createClock();
+            var called = false;
+            clock.nextTick(function () {
+                called = true;
+            });
+            clock.runAll();
+            assert(called);
+        });
+
+        it("runs when runMicrotasks is called on the clock", function () {
+            var clock = lolex.createClock();
+            var called = false;
+            clock.nextTick(function () {
+                called = true;
+            });
+            clock.runMicrotasks();
+            assert(called);
+        });
+
+        it("respects loopLimit from below in runMicrotasks", function () {
+            var clock = lolex.createClock(0, 100);
+            for (var i = 0; i < 99; i++) {
+                // eslint-disable-next-line no-loop-func,ie11/no-loop-func
+                clock.nextTick(function () {
+                    i--;
+                });
+            }
+            clock.runMicrotasks();
+            assert.equals(i, 0);
+        });
+
+        it("respects loopLimit from above in runMicrotasks", function () {
+            var clock = lolex.createClock(0, 100);
+            for (var i = 0; i < 120; i++) {
+                // eslint-disable-next-line ie11/no-loop-func
+                clock.nextTick(function () { });
+            }
+            assert.exception(function () { clock.runMicrotasks(); });
+        });
+
+
+        it("detects infinite nextTick cycles", function () {
+            var clock = lolex.createClock(0, 1000);
+            clock.nextTick(function repeat() {
+                clock.nextTick(repeat);
+            });
+            assert.exception(function () { clock.runMicrotasks(); });
+        });
+
+        it("runs with timers - and before them", function () {
+            var clock = lolex.createClock();
+            var last = "";
+            var called = false;
+            clock.nextTick(function () {
+                called = true;
+                last = "tick";
+            });
+            clock.setTimeout(function () {
+                last = "timeout";
+            });
+            clock.runAll();
+            assert(called);
+            assert.equals(last, "timeout");
+        });
+
+        it("runs when time is progressed", function () {
+            var clock = lolex.createClock();
+            var called = false;
+            clock.nextTick(function () {
+                called = true;
+            });
+            assert(!called);
+            clock.tick(0);
+            assert(called);
+        });
+
+        it("runs between timers", function () {
+            var clock = lolex.createClock();
+            var order = [];
+            clock.setTimeout(function () {
+                order.push("timer-1");
+                clock.nextTick(function () {
+                    order.push("tick");
+                });
+            });
+
+            clock.setTimeout(function () {
+                order.push("timer-2");
+            });
+            clock.runAll();
+            assert.same(order[0], "timer-1");
+            assert.same(order[1], "tick");
+            assert.same(order[2], "timer-2");
+        });
+
+        it("installs with microticks", function () {
+            var clock = lolex.install({toFake: ["nextTick"]});
+            var called = false;
+            process.nextTick(function () {
+                called = true;
+            });
+            clock.runAll();
+            assert(called);
+            clock.uninstall();
+        });
+
+        it("installs with microticks and timers in order", function () {
+            var clock = lolex.install({toFake: ["nextTick", "setTimeout"]});
+            var order = [];
+            setTimeout(function () {
+                order.push("timer-1");
+                process.nextTick(function () {
+                    order.push("tick");
+                });
+            });
+            setTimeout(function () {
+                order.push("timer-2");
+            });
+            clock.runAll();
+            assert.same(order[0], "timer-1");
+            assert.same(order[1], "tick");
+            assert.same(order[2], "timer-2");
+            clock.uninstall();
+        });
+
+        it("uninstalls", function () {
+            var clock = lolex.install({toFake: ["nextTick"]});
+            clock.uninstall();
+            var called = false;
+            process.nextTick(function () {
+                called = true;
+            });
+            clock.runAll();
+            assert(!called);
+        });
+
+        it("returns an empty list of timers on immediate uninstall", function () {
+            var clock = lolex.install();
+            var timers = clock.uninstall();
+            assert.equals(timers, []);
+        });
+
+
+        it("returns a timer if uninstalling before it's called", function () {
+            var clock = lolex.install();
+            clock.setTimeout(function () {}, 100);
+            var timers = clock.uninstall();
+            assert.equals(timers.length, 1);
+            assert.equals(timers[0].createdAt, clock.now);
+            assert.equals(timers[0].callAt, clock.now + 100);
+            assert(typeof timers[0].id !== "undefined");
+        });
+
+        it("does not return already executed timers on uninstall", function () {
+            var clock = lolex.install();
+            clock.setTimeout(function () {}, 100);
+            clock.setTimeout(function () {}, 200);
+            clock.tick(100);
+            var timers = clock.uninstall();
+            assert.equals(timers.length, 1);
+            assert.equals(timers[0].createdAt, clock.now - 100);
+            assert.equals(timers[0].callAt, clock.now + 100);
+            assert(typeof timers[0].id !== "undefined");
+        });
+
+        it("returns multiple timers on uninstall if created", function () {
+            var clock = lolex.install();
+            for (var i = 0; i < 5; i++) {
+                // yes, it's silly to create a function in a loop. This is a test, we can live with it
+                // eslint-disable-next-line ie11/no-loop-func
+                clock.setTimeout(function () {}, 100 * i);
+            }
+            var timers = clock.uninstall();
+            assert.equals(timers.length, 5);
+            for (i = 0; i < 5; i++) {
+                assert.equals(timers[i].createdAt, clock.now);
+                assert.equals(timers[i].callAt, clock.now + 100 * i);
+            }
+            assert(typeof timers[0].id !== "undefined");
+        });
+
+        it("passes arguments when installed - GitHub#122", function () {
+            var clock = lolex.install({toFake: ["nextTick"]});
+            var called = false;
+            process.nextTick(function (value) {
+                called = value;
+            }, true);
+            clock.runAll();
+            assert(called);
+            clock.uninstall();
+        });
+
+        it("does not install by default - GitHub#126", function (done) {
+            var clock = lolex.install();
+            var spy = sinon.spy(clock, "nextTick");
+            var called = false;
+            process.nextTick(function (value) {
+                called = value;
+                assert(called);
+                assert(!spy.called);
+                clock.uninstall();
+                done();
+            }, true);
+        });
+    });
 });

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -114,6 +114,58 @@ describe("issue sinon#1852", function () {
     });
 });
 
+describe("issue #207 - nanosecond round-off errors on high-res timer", function () {
+    var clock;
+
+    afterEach(function() {
+        clock.uninstall();
+    });
+
+    it("should not round off nanosecond arithmetic on hrtime - case 1", function () {
+        clock = lolex.install()
+
+        clock.tick(1022.7791)
+
+        var nanos = clock.hrtime([0, 2*1e7])[1];
+        assert.equals(nanos, 2779100);
+    });
+
+    it("should not round off nanosecond arithmetic on hrtime - case 2", function () {
+        clock = lolex.install({
+            now: new Date("2018-09-12T08:58:33.742000000Z").getTime(),
+            toFake: ["hrtime"]
+        });
+        var start = clock.hrtime();
+        clock.tick(123.493);
+
+        var nanos = clock.hrtime(start)[1];
+        assert.equals(nanos, 123493000);
+    });
+
+    it("should always set 'now' to an integer value when ticking with sub-millisecond precision", function (){
+        clock = lolex.install();
+        clock.tick(2.993);
+
+        assert.equals(clock.now, 2);
+    });
+
+    it("should adjust adjust the 'now' value when the nano-remainder overflows", function (){
+        clock = lolex.install();
+        clock.tick(0.993);
+        clock.tick(.5);
+
+        assert.equals(clock.now, 1);
+    });
+
+    it("should adjust adjust the 'now' value when the nano-remainder becomes negative", function (){
+        clock = lolex.install();
+        clock.tick(1.2);
+        clock.tick(-0.5);
+
+        assert.equals(clock.now, 0);
+    });
+});
+
 describe("lolex", function () {
 
     describe("setTimeout", function () {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -918,6 +918,13 @@ describe("lolex", function () {
             assert.equals(stub.callCount, 1);
         });
 
+        it("throws on negative ticks", function () {
+            var clock = this.clock;
+
+            assert.exception(function () {
+                clock.tick(-500);
+            }, {message: "Negative ticks are not supported"});
+        });
     });
 
     describe("next", function () {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -157,10 +157,35 @@ describe("issue #207 - nanosecond round-off errors on high-res timer", function 
         assert.equals(clock.now, 1);
     });
 
-    it("should adjust adjust the 'now' value when the nano-remainder becomes negative", function (){
-        clock = lolex.install();
-        clock.tick(1.2);
-        clock.tick(-0.5);
+    it("should floor negative now values", function (){
+        clock = lolex.install({now: -1.2});
+
+        assert.equals(clock.now, -2);
+    });
+
+    it("should floor start times", function (){
+        clock = lolex.install({now: 1.2});
+        assert.equals(clock.now, 1);
+    });
+
+    it("should floor negative start times", function (){
+        clock = lolex.install({now: -1.2});
+        assert.equals(clock.now, -2);
+    });
+
+    it("should handle ticks on the negative side of the Epoch", function (){
+        clock = lolex.install({now: -2});
+        clock.tick(0.8); // -1.2
+        clock.tick(0.5); // -0.7
+
+        assert.equals(clock.now, -1);
+    });
+
+    it("should handle multiple non-integer ticks", function (){
+        clock = lolex.install({now: -2});
+        clock.tick(1.1); // -0.9
+        clock.tick(0.5);
+        clock.tick(0.5); // 0.1
 
         assert.equals(clock.now, 0);
     });
@@ -1379,9 +1404,9 @@ describe("lolex", function () {
         it("resets hrTime - issue #206", function () {
             var clock = lolex.createClock();
             clock.tick(100);
-            assert.equals(clock.hrNow, 100);
+            assert.equals(clock.hrtime(), [0, 100*1e6]);
             clock.reset();
-            assert.equals(clock.hrNow, 0);
+            assert.equals(clock.hrtime(), [0, 0]);
         });
     });
 

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -142,6 +142,14 @@ describe("issue #207 - nanosecond round-off errors on high-res timer", function 
             var nanos = clock.hrtime(start)[1];
             assert.equals(nanos, 123493000);
         });
+
+        it("should truncate sub-nanosecond ticks", function () {
+            clock = lolex.install();
+            clock.tick(0.123456789);
+
+            var nanos = clock.hrtime()[1];
+            assert.equals(nanos, 123456);
+        });
     }
 
     it("should always set 'now' to an integer value when ticking with sub-millisecond precision", function () {


### PR DESCRIPTION
#### Purpose 
This is a fix for #207, which dealt in round-off errors. 

Other notable changes are:
- removes `clock.hrNow`. Should not be an issue as it's an internal detail not documented in our API
- throws on negative ticks. This is a breaking API change, but I would be very surprised if it affected anyone, as this essentially means backwards time travel.
- change some test structure, replacing `if()` blocks with conditional `this.skip()`

#### Background
This PR fixes #207 by doing away with floats for representing time; opting to store milliseconds and millisecond decimals separately. We could have avoided the complications of storing two parts by opting to store all ticks as nanoseconds, but that would pose other round-off issues when adding/subtracting high-value milliseconds. Javascript is unable to represent the epoch as nanos due to too few bits for the `Number` type. See discussion in #207 for more background. The test cases found through that issue is included in the test suite.

I tried a few approaches, but this approach was the simplest one to follow and allowed me to do away with a bit of code. For a while I had problems with the behaviour that setting system time should not affect the hrtime, and I tried recreating the approach of using a separate clock for `hrtime` (which was the purpose `hrNow` served), but keeping the two clocks in sync, including the nanosecond offsets, with all the existing `updateHrTime()` callsites was just too much for my simple mind to fathom :boom: Instead I found a simpler solution which was just to record the delta between the new and old time when a new system clock is set and use that to compensate in the `hrtime()` function (see ae83b27).

closes #207

#### Verifying
1. clone the repo and checkout the branch
1. `npm install && npm test`
1. `npm run test-cloud` (if you have sauce labs credentials)
1. `npm link` - will install this as your local `lolex`
1. Require `lolex` in your repo and run against your own code/tests