### PR TITLE
Add countTimers method

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -200,6 +200,11 @@ available in both browser & node environments.
 
 Cancels the callback scheduled by the provided id.
 
+### `clock.countTimers()`
+
+Returns the number of waiting timers. This can be used to assert that a test
+finishes without leaking any timers.
+
 ### `clock.hrtime(prevTime?)`
 Only available in Node.js, mimicks process.hrtime().
 

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -257,7 +257,6 @@ function withGlobal(_global) {
         return timer.id;
     }
 
-
     /* eslint consistent-return: "off" */
     function compareTimers(a, b) {
         // Sort first by absolute timing
@@ -572,6 +571,10 @@ function withGlobal(_global) {
 
         clock.clearImmediate = function clearImmediate(timerId) {
             return clearTimer(clock, timerId, "Immediate");
+        };
+
+        clock.countTimers = function countTimers() {
+            return Object.keys(clock.timers).length;
         };
 
         clock.requestAnimationFrame = function requestAnimationFrame(func) {

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -574,7 +574,7 @@ function withGlobal(_global) {
         };
 
         clock.countTimers = function countTimers() {
-            return Object.keys(clock.timers).length;
+            return Object.keys(clock.timers || {}).length;
         };
 
         clock.requestAnimationFrame = function requestAnimationFrame(func) {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -432,6 +432,22 @@ describe("lolex", function () {
 
     });
 
+    describe("countTimers", function () {
+
+        beforeEach(function () {
+            this.clock = lolex.createClock();
+        });
+
+        it("counts remaining timers", function () {
+            this.clock.setTimeout(NOOP, 100);
+            this.clock.setTimeout(NOOP, 200);
+            this.clock.setTimeout(NOOP, 300);
+            this.clock.tick(150);
+            assert.equals(this.clock.countTimers(), 2);
+        });
+
+    });
+
     describe("tick", function () {
 
         beforeEach(function () {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -438,6 +438,11 @@ describe("lolex", function () {
             this.clock = lolex.createClock();
         });
 
+        it("return zero for a fresh clock", function () {
+            assert.equals(this.clock.countTimers(), 0);
+        });
+
+
         it("counts remaining timers", function () {
             this.clock.setTimeout(NOOP, 100);
             this.clock.setTimeout(NOOP, 200);


### PR DESCRIPTION
Fixes #163 and #213 by adding a method to count the waiting timers. I (and I believe others: Facebook, @radarfox, @SimenB, ?) want this method to check for "timer leaks" in our tests.