### PR TITLE
[WIP] queueMicrotask() ExperimentalWarning in Node

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -33,7 +33,7 @@ function withGlobal(_global) {
     var nextTickPresent = (_global.process && typeof _global.process.nextTick === "function");
     var performancePresent = (_global.performance && typeof _global.performance.now === "function");
     var hasPerformancePrototype = (_global.Performance && (typeof _global.Performance).match(/^(function|object)$/));
-    var queueMicrotaskPresent = (typeof _global.queueMicrotask === "function");
+    var queueMicrotaskPresent = (_global.hasOwnProperty("queueMicrotask"));
     var requestAnimationFramePresent = (
         _global.requestAnimationFrame && typeof _global.requestAnimationFrame === "function"
     );
@@ -493,8 +493,9 @@ function withGlobal(_global) {
     if (requestAnimationFramePresent) {
         timers.requestAnimationFrame = _global.requestAnimationFrame;
     }
+
     if (queueMicrotaskPresent) {
-        timers.queueMicrotask = _global.queueMicrotask;
+        timers.queueMicrotask = true;
     }
 
     if (cancelAnimationFramePresent) {
@@ -897,7 +898,9 @@ function withGlobal(_global) {
 
         if (clock.methods.length === 0) {
             // do not fake nextTick by default - GitHub#126
-            clock.methods = keys(timers).filter(function (key) {return key !== "nextTick";});
+            clock.methods = keys(timers).filter(function (key) {
+                return key !== "nextTick" && key !== "queueMicrotask";
+            });
         }
 
         for (i = 0, l = clock.methods.length; i < l; i++) {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -2545,7 +2545,7 @@ describe("lolex", function () {
         });
         it("runs with timers and before them", function () {
             var last = "";
-            clock.runMicrotasks(function () {
+            clock.queueMicrotask(function () {
                 called = true;
                 last = "tick";
             });


### PR DESCRIPTION
Hello, guys.

I did a quick fix for #232 not faking this method by default like `nextTick`, but have a couple of questions.

`--trace-warnings` point on `_global.queueMicrotask` usage in the code.

There are two places in the code:

1. Feature detection (I fixed in @ehmicky way). Not sure about that, because it gives `true` when property value is `null` or `undefined`. What do you think?
2. And when it stores in `lolex.timers`. What is the purpose of storing all the timers methods that supported by particular environment there instead of storing only just list of them? As I got from the code `hijackMethod` assign `_queueMicrotask` to `_global.queueMicrotask`, but not to `timers.queueMicrotask`. I might be incorrect.

Now it is giving warnings only with `lolex.install({ toFake: ["queueMicrotask"] })`.

I'm going to add some tests for this.

@benjamingr I fixed queueMicrotask() test "runs with timers and before them", which was failed, I think it was the typo.

Any comments?