### PR TITLE
Return empty arrays for performance.getEntries, other relevant methods

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -850,7 +850,7 @@ function withGlobal(_global) {
                 Object
                     .getOwnPropertyNames(proto)
                     .forEach(function (name) {
-                        if (name.slice(0, 10) === "getEntries") {
+                        if (name.indexOf("getEntries") === 0) {
                             // match expected return type for getEntries functions
                             clock.performance[name] = NOOP_ARRAY;
                         } else {

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -27,6 +27,7 @@ function withGlobal(_global) {
     // see https://github.com/cjohansen/Sinon.JS/pull/436
 
     var NOOP = function () { return undefined; };
+    var NOOP_ARRAY = function () { return []; };
     var timeoutResult = _global.setTimeout(NOOP, 0);
     var addTimerReturnsObject = typeof timeoutResult === "object";
     var hrtimePresent = (_global.process && typeof _global.process.hrtime === "function");
@@ -849,7 +850,12 @@ function withGlobal(_global) {
                 Object
                     .getOwnPropertyNames(proto)
                     .forEach(function (name) {
-                        clock.performance[name] = NOOP;
+                        if (name.slice(0, 10) === "getEntries") {
+                            // match expected return type for getEntries functions
+                            clock.performance[name] = NOOP_ARRAY;
+                        } else {
+                            clock.performance[name] = NOOP;
+                        }
                     });
             }
 

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -2084,6 +2084,24 @@ describe("lolex", function () {
                 delete Performance.prototype.someFunc2;
                 delete Performance.prototype.someFunc3;
             });
+
+            it("should replace the getEntries, getEntriesByX methods with noops that return []", function () {
+                Performance.prototype.getEntries =
+                Performance.prototype.getEntriesByName =
+                Performance.prototype.getEntriesByType = function () { return ["foo"]; };
+
+                this.clock = lolex.install();
+
+                assert.equals(performance.getEntries(), []);
+                assert.equals(performance.getEntriesByName(), []);
+                assert.equals(performance.getEntriesByType(), []);
+
+                this.clock.uninstall();
+
+                delete Performance.prototype.getEntries;
+                delete Performance.prototype.getEntriesByName;
+                delete Performance.prototype.getEntriesByTime;
+            });
         }
 
         if (Object.getPrototypeOf(global)) {

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -2098,6 +2098,10 @@ describe("lolex", function () {
 
                 this.clock.uninstall();
 
+                assert.equals(performance.getEntries(), ["foo"]);
+                assert.equals(performance.getEntriesByName(), ["foo"]);
+                assert.equals(performance.getEntriesByType(), ["foo"]);
+
                 delete Performance.prototype.getEntries;
                 delete Performance.prototype.getEntriesByName;
                 delete Performance.prototype.getEntriesByTime;


### PR DESCRIPTION
#### Purpose (TL;DR)
Fix issues caused by applications which expect `performance.getEntries`, `performance.getEntriesByName`, and `performance.getEntriesByType` to return arrays (such as Facebook SDK - downstream issue: cypress-io/cypress#3625)

Right now, lolex clobbers these with `() => undefined`. Just using `() => []` instead would fix this.

#### Background (Problem in detail)

MDN page for Performance functions: https://developer.mozilla.org/en-US/docs/Web/API/Performance

Only 5 have non-undefined return types. The other 2 (besides `getEntries.*`) are:
* `now()` - already done by lolex
* `toJSON()` - not handled, not sure if there's a good way to mock this value

#### Solution 

Just have those 3 methods return `[]` when `lolex.install()` is called, instead of `undefined`