### PR TITLE
Fix jsdom 2

### DIFF
--- a/integration-test/lolex-integration-test.js
+++ b/integration-test/lolex-integration-test.js
@@ -57,3 +57,83 @@ describe("withGlobal", function () {
         clock.uninstall();
     });
 });
+
+describe("globally configured browser objects", function () {
+    var withGlobal, originalDescriptors;
+
+    // Used to support Node 6 which doesn't support Object.getOwnPropertyDescriptors
+    function getOwnPropertyDescriptors(obj) {
+        var propertyNames = Object.getOwnPropertyNames(obj);
+        var result = {};
+        propertyNames.forEach(function (name) {
+            var descriptor = Object.getOwnPropertyDescriptor(obj, name);
+            result[name] = descriptor;
+        });
+
+        return result;
+    }
+
+    // We use a set up function instead of beforeEach to avoid Mocha's check leaks detector
+    function setUpGlobal() {
+        // Configuration taken from from here https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md
+        var dom = new jsdom.JSDOM("<!doctype html><html><body></body></html>");
+        var window = dom.window;
+
+        function copyProps(src, target) {
+            originalDescriptors = getOwnPropertyDescriptors(target);
+            Object.defineProperties(target, getOwnPropertyDescriptors(src));
+            Object.defineProperties(target, originalDescriptors);
+        }
+
+        global.window = window;
+        global.document = window.document;
+        global.navigator = {
+            userAgent: "node.js"
+        };
+        global.requestAnimationFrame = function (callback) {
+            return setTimeout(callback, 0);
+        };
+        global.cancelAnimationFrame = function (id) {
+            clearTimeout(id);
+        };
+        copyProps(window, global);
+
+        withGlobal = lolex.withGlobal(global);
+    }
+
+    function tearDownGlobal() {
+        var originalDescriptorNames = Object.keys(originalDescriptors);
+        var windowDescriptorNames = Object.getOwnPropertyNames(global.window);
+        windowDescriptorNames.forEach(function (descriptorName) {
+            if (!originalDescriptorNames.includes(descriptorName)) {
+                delete global[descriptorName];
+            }
+        });
+
+        delete global.window;
+        delete global.document;
+        delete global.navigator;
+        delete global.requestAnimationFrame;
+        delete global.cancelAnimationFrame;
+    }
+
+    it("correctly instantiates and tears down", function () {
+        setUpGlobal();
+
+        try {
+            var mockNow = new Date("1990-1-1");
+            var clock = withGlobal.install({
+                now: mockNow
+            });
+
+            assert.equals(new Date(Date.now()), mockNow);
+            assert.equals(new Date(), mockNow);
+
+            clock.uninstall();
+
+            assert(new Date().valueOf() !== mockNow.valueOf());
+        } finally {
+            tearDownGlobal();
+        }
+    });
+});

--- a/lolex.js
+++ b/lolex.js
@@ -416,7 +416,12 @@ function withGlobal(_global) {
             } else if (method === "nextTick" && target.process) {
                 target.process.nextTick = clock[installedNextTick];
             } else if (method === "performance") {
-                target[method] = clock["_" + method];
+                var originalPerfDescriptor = Object.getOwnPropertyDescriptor(clock, "_" + method);
+                if (originalPerfDescriptor && originalPerfDescriptor.get && !originalPerfDescriptor.set) {
+                    Object.defineProperty(target, method, originalPerfDescriptor);
+                } else if (originalPerfDescriptor.configurable) {
+                    target[method] = clock["_" + method];
+                }
             } else {
                 if (target[method] && target[method].hadOwnProperty) {
                     target[method] = clock["_" + method];
@@ -452,7 +457,16 @@ function withGlobal(_global) {
             var date = mirrorDateProperties(clock[method], target[method]);
             target[method] = date;
         } else if (method === "performance") {
-            target[method] = clock[method];
+            var originalPerfDescriptor = Object.getOwnPropertyDescriptor(target, method);
+            // JSDOM has a read only performance field so we have to save/copy it differently
+            if (originalPerfDescriptor && originalPerfDescriptor.get && !originalPerfDescriptor.set) {
+                Object.defineProperty(clock, "_" + method, originalPerfDescriptor);
+
+                var perfDescriptor = Object.getOwnPropertyDescriptor(clock, method);
+                Object.defineProperty(target, method, perfDescriptor);
+            } else {
+                target[method] = clock[method];
+            }
         } else {
             target[method] = function () {
                 return clock[method].apply(clock, arguments);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix #243 by changing the way the `performance` field gets overwritten.  This time without breaking some browsers.

#### Background (Problem in detail)  - optional

JSDOM has a read only `performance` field.  So, when JSDOM is configured to provide [global values](https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md), lolex will error on init. This is because it can't overwrite the global `performance` field. 
