### PR TITLE
Use `--no-detect-globals` to bundle and test lolex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -615,9 +615,9 @@
       "dev": true
     },
     "brout": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/brout/-/brout-1.2.0.tgz",
-      "integrity": "sha1-B3Hav3ltMS8KfB8SgeAPdmDPcC8=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/brout/-/brout-1.3.0.tgz",
+      "integrity": "sha512-wCMjZMH6sCUytoS/aqJBajJREN2wS1GnsNyBqB/Ss1hrcCh0no+Zgk+ebFp9s2yh5lxGfXBRXwNH2N3Ma2RFdQ==",
       "dev": true,
       "requires": {
         "through2": "^2.0.0"
@@ -1451,12 +1451,12 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -1788,9 +1788,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
     "es6-promisify": {
@@ -2136,6 +2136,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -2262,6 +2268,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -4697,12 +4709,12 @@
       }
     },
     "mocaccino": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/mocaccino/-/mocaccino-4.1.1.tgz",
-      "integrity": "sha512-/sYoNH7bl+73XZEtcFt0xLt9WZckr65FDzlW2MumQbE21JFJaXrtlSs+j9rfucZmw/yzFiBYL+apQmlw/0GP6A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/mocaccino/-/mocaccino-4.1.2.tgz",
+      "integrity": "sha512-lTlZ47MiMVco1gQhYGh75/U6t6cMNxLVhQTLNsJWPZlWY9dlF+SS9vKrnjaNpRzYThh8yVJpI8+hpChyUj+Qzg==",
       "dev": true,
       "requires": {
-        "brout": "^1.1.0",
+        "brout": "^1.3.0",
         "listen": "^1.0.0",
         "mocha": "^5.2.0",
         "resolve": "^1.8.1",
@@ -4715,6 +4727,15 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "he": {
           "version": "1.1.1",
@@ -4751,6 +4772,12 @@
               }
             }
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
@@ -4909,19 +4936,19 @@
       }
     },
     "mochify": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/mochify/-/mochify-6.5.0.tgz",
-      "integrity": "sha512-pMDyU0LrMNT7EInYEWNfyZ1NyYzQOi5TYagT4qODMTGZoV/+Nfmz2TVoEv9r+0zyh/sWi66+Prt8MBooZKts7w==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/mochify/-/mochify-6.6.0.tgz",
+      "integrity": "sha512-4rM4N/+sevEEa3RKq3VAcMXMBEWgLtXOgdrvBUDuRr2Bne91C+Ka5yQv9cXHEbS7iQm/YAbgszyHkBHWMuX+4w==",
       "dev": true,
       "requires": {
-        "brout": "^1.1.0",
+        "brout": "^1.3.0",
         "browserify": "^16.2.3",
         "consolify": "^2.1.0",
         "coverify": "^1.4.1",
         "glob": "^7.1.2",
         "mime": "^2.3.1",
         "min-wd": "^2.11.0",
-        "mocaccino": "^4.1.0",
+        "mocaccino": "^4.1.2",
         "mocha": "^5.2.0",
         "puppeteer": "^1.19.0",
         "resolve": "^1.5.0",
@@ -4931,67 +4958,20 @@
         "watchify": "^3.11.1"
       },
       "dependencies": {
-        "browserify": {
-          "version": "16.5.0",
-          "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.0.tgz",
-          "integrity": "sha512-6bfI3cl76YLAnCZ75AGu/XPOsqUhRyc0F/olGIJeCxtfxF2HvPKEcmjU9M8oAPxl4uBY1U7Nry33Q6koV3f2iw==",
-          "dev": true,
-          "requires": {
-            "JSONStream": "^1.0.3",
-            "assert": "^1.4.0",
-            "browser-pack": "^6.0.1",
-            "browser-resolve": "^1.11.0",
-            "browserify-zlib": "~0.2.0",
-            "buffer": "^5.0.2",
-            "cached-path-relative": "^1.0.0",
-            "concat-stream": "^1.6.0",
-            "console-browserify": "^1.1.0",
-            "constants-browserify": "~1.0.0",
-            "crypto-browserify": "^3.0.0",
-            "defined": "^1.0.0",
-            "deps-sort": "^2.0.0",
-            "domain-browser": "^1.2.0",
-            "duplexer2": "~0.1.2",
-            "events": "^2.0.0",
-            "glob": "^7.1.0",
-            "has": "^1.0.0",
-            "htmlescape": "^1.1.0",
-            "https-browserify": "^1.0.0",
-            "inherits": "~2.0.1",
-            "insert-module-globals": "^7.0.0",
-            "labeled-stream-splicer": "^2.0.0",
-            "mkdirp": "^0.5.0",
-            "module-deps": "^6.0.0",
-            "os-browserify": "~0.3.0",
-            "parents": "^1.0.1",
-            "path-browserify": "~0.0.0",
-            "process": "~0.11.0",
-            "punycode": "^1.3.2",
-            "querystring-es3": "~0.2.0",
-            "read-only-stream": "^2.0.0",
-            "readable-stream": "^2.0.2",
-            "resolve": "^1.1.4",
-            "shasum": "^1.0.0",
-            "shell-quote": "^1.6.1",
-            "stream-browserify": "^2.0.0",
-            "stream-http": "^3.0.0",
-            "string_decoder": "^1.1.1",
-            "subarg": "^1.0.0",
-            "syntax-error": "^1.1.1",
-            "through2": "^2.0.0",
-            "timers-browserify": "^1.0.1",
-            "tty-browserify": "0.0.1",
-            "url": "~0.11.0",
-            "util": "~0.10.1",
-            "vm-browserify": "^1.0.0",
-            "xtend": "^4.0.0"
-          }
-        },
         "commander": {
           "version": "2.15.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "he": {
           "version": "1.1.1",
@@ -5018,30 +4998,11 @@
             "supports-color": "5.4.0"
           }
         },
-        "stream-http": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz",
-          "integrity": "sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==",
-          "dev": true,
-          "requires": {
-            "builtin-status-codes": "^3.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^3.0.6",
-            "xtend": "^4.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-              "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            }
-          }
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
@@ -5078,9 +5039,9 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "mute-stream": {
@@ -5723,12 +5684,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         }
       }
     },
@@ -6272,6 +6227,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "scripts": {
     "lint": "eslint .",
     "test-node": "mocha test/ integration-test/ -R dot --check-leaks",
-    "test-headless": "mochify",
-    "test-cloud": "mochify --wd",
+    "test-headless": "mochify --no-detect-globals",
+    "test-cloud": "mochify --wd --no-detect-globals",
     "test": "npm run lint && npm run test-node && npm run test-headless",
-    "bundle": "browserify -s lolex -o lolex.js src/lolex-src.js",
+    "bundle": "browserify --no-detect-globals -s lolex -o lolex.js src/lolex-src.js",
     "prepublishOnly": "npm run bundle",
     "preversion": "./scripts/preversion.sh",
     "version": "./scripts/version.sh",
@@ -43,7 +43,7 @@
     "jsdom": "15.1.1",
     "lint-staged": "9.4.1",
     "mocha": "6.2.1",
-    "mochify": "6.5.0",
+    "mochify": "6.6.0",
     "npm-run-all": "4.1.5"
   },
   "eslintConfig": {

--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -973,7 +973,7 @@ function withGlobal(_global) {
     };
 }
 
-var defaultImplementation = withGlobal(global || window);
+var defaultImplementation = withGlobal(typeof global !== "undefined" ? global : window);
 
 exports.timers = defaultImplementation.timers;
 exports.createClock = defaultImplementation.createClock;

--- a/test/lolex-test.js
+++ b/test/lolex-test.js
@@ -6,14 +6,30 @@
  */
 "use strict";
 
-if (typeof require === "function" && typeof module === "object") {
-    var assert = require("@sinonjs/referee-sinon").assert;
-    var refute = require("@sinonjs/referee-sinon").refute;
-    var lolex = require("../src/lolex-src");
-    var sinon = require("@sinonjs/referee-sinon").sinon;
+/*
+ * FIXME This is an interim hack to break a circular dependency between lolex,
+ * nise and sinon.
+ *
+ * 1. Load lolex firt, without defining global, verifying the ReferenceError is gone.
+ */
+var lolex = require("../src/lolex-src");
 
-    global.lolex = lolex; // For testing eval
+/*
+ * 2. Define global, if missing.
+ */
+if (typeof global === "undefined") {
+    window.global = window;
 }
+
+/*
+ * 3. Load sinon with global defined.
+ */
+var assert = require("@sinonjs/referee-sinon").assert;
+var refute = require("@sinonjs/referee-sinon").refute;
+var sinon = require("@sinonjs/referee-sinon").sinon;
+
+var globalObject = typeof global !== "undefined" ? global : window;
+globalObject.lolex = lolex; // For testing eval
 
 var GlobalDate = Date;
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Our own global check `global || window` only happened to work because browserify wrapped the whole thing with the correct check. With this fix, browserify will not define `global` itself.

Note that there is a very ugly hack in the top of the test file now that can / should be removed once nise and sinon received similar updates.

<!--
#### Background (Problem in detail)  - optional
-->

See https://github.com/mantoni/mochify.js/pull/209 and linked issues.