### PR TITLE
Fix global ReferenceError

### DIFF
--- a/src/lolex-src.js
+++ b/src/lolex-src.js
@@ -955,9 +955,9 @@ function withGlobal(_global) {
             return doTick(tickValue, false);
         };
 
-        if (typeof global.Promise !== "undefined") {
+        if (typeof _global.Promise !== "undefined") {
             clock.tickAsync = function tickAsync(ms) {
-                return new global.Promise(function(resolve, reject) {
+                return new _global.Promise(function(resolve, reject) {
                     originalSetTimeout(function() {
                         try {
                             doTick(ms, true, resolve, reject);
@@ -987,9 +987,9 @@ function withGlobal(_global) {
             }
         };
 
-        if (typeof global.Promise !== "undefined") {
+        if (typeof _global.Promise !== "undefined") {
             clock.nextAsync = function nextAsync() {
-                return new global.Promise(function(resolve, reject) {
+                return new _global.Promise(function(resolve, reject) {
                     originalSetTimeout(function() {
                         try {
                             var timer = firstTimer(clock);
@@ -1050,9 +1050,9 @@ function withGlobal(_global) {
             return clock.tick(getTimeToNextFrame());
         };
 
-        if (typeof global.Promise !== "undefined") {
+        if (typeof _global.Promise !== "undefined") {
             clock.runAllAsync = function runAllAsync() {
-                return new global.Promise(function(resolve, reject) {
+                return new _global.Promise(function(resolve, reject) {
                     var i = 0;
                     function doRun() {
                         originalSetTimeout(function() {
@@ -1106,9 +1106,9 @@ function withGlobal(_global) {
             return clock.tick(timer.callAt - clock.now);
         };
 
-        if (typeof global.Promise !== "undefined") {
+        if (typeof _global.Promise !== "undefined") {
             clock.runToLastAsync = function runToLastAsync() {
-                return new global.Promise(function(resolve, reject) {
+                return new _global.Promise(function(resolve, reject) {
                     originalSetTimeout(function() {
                         try {
                             var timer = lastTimer(clock);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fixes #272 which was introduced by #270.

Inspect the result of bundling this branch here: https://jsbin.com/godesuduxo/edit?html,js,console

#### Background (Problem in detail)  - optional

The `global` variable is not provided by Browerify anymore. I don't fully understand why this isn't caught by test runs in browsers yet. Will need to investigate further.

#### Solution  - optional

Use the `_global` variable which is set to `window` in browsers.