### PR TITLE
Restore Date object support broken by PR #556

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -639,7 +639,7 @@ function withGlobal(_global) {
         if (!epoch) {
             return 0;
         }
-        if (epoch instanceof Date) {
+        if (typeof epoch.getTime === "function") {
             return epoch.getTime();
         }
         if (typeof epoch === "number") {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory                                                                                                          
                                                                                                                                            
Fix cross-realm Date regression introduced in [#556](https://github.com/sinonjs/fake-timers/pull/556).                                                                                       
                                                                                                                                            
#### Background (Problem in detail)                                                                                                       
                                                                                                                                            
The public API accepts `Date | number`, but the change in #556 from `typeof epoch.getTime === "function"` to `instanceof Date` broke support for Date objects from different realms (iframes, vm contexts, etc.), since `instanceof` fails across realms.                      
                                                                                                                                            
Error: `TypeError: now should be milliseconds since UNIX epoch`                                                                           
                                                                                                                                            
Reproduction:                                                                                                                             
                                                                                                                                            
```js                                                                                                                                     
const vm = require("vm");                                                                                                                 
const FakeTimers = require("@sinonjs/fake-timers");                                                                                       
const crossRealmDate = vm.runInNewContext("new Date('2026-04-02')");                                                                      
const clock = FakeTimers.install();                                                                                                       
clock.setSystemTime(crossRealmDate); // throws TypeError                                                                                  
```      
                                                                                                                                     
#### Solution                                                                                                                                  
                                                                                                                                            
Restore the original duck-typing approach `(typeof epoch.getTime === "function")` that worked before #556.                                  