### PR TITLE
Do not let constructor appear in Object.getOwnPropertyNames for fake Dates

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -786,10 +786,14 @@ function withGlobal(_global) {
 
                 // ensures identity checks using the constructor prop still works
                 // this should have no other functional effect
-                Object.defineProperty(this, "constructor", {
-                    value: NativeDate,
-                    enumerable: false,
-                });
+                Object.defineProperty(
+                    Object.getPrototypeOf(this),
+                    "constructor",
+                    {
+                        value: NativeDate,
+                        enumerable: false,
+                    },
+                );
             }
 
             static [Symbol.hasInstance](instance) {

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -822,10 +822,14 @@ function withGlobal(_global) {
 
                 // ensures identity checks using the constructor prop still works
                 // this should have no other functional effect
-                Object.defineProperty(this, "constructor", {
-                    value: NativeDate,
-                    enumerable: false,
-                });
+                Object.defineProperty(
+                    Object.getPrototypeOf(this),
+                    "constructor",
+                    {
+                        value: NativeDate,
+                        enumerable: false,
+                    },
+                );
             }
 
             static [Symbol.hasInstance](instance) {

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3368,6 +3368,15 @@ describe("FakeTimers", function () {
             assert.equals(Object.keys(date).length, 0);
         });
 
+        it("creates Date objects where the constructor prop is not an own property", function () {
+            const date = new this.clock.Date();
+            const date2 = new this.clock.Date();
+
+            assert(Object.getPrototypeOf(date) === Object.getPrototypeOf(date2))
+
+            assert.equals(Object.getOwnPropertyNames(date).length, 0);
+        });
+
         it("creates Date objects representing clock time", function () {
             const date = new this.clock.Date();
 

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3371,6 +3371,17 @@ describe("FakeTimers", function () {
             assert.equals(Object.keys(date).length, 0);
         });
 
+        it("creates Date objects where the constructor prop is not an own property", function () {
+            const date = new this.clock.Date();
+            const date2 = new this.clock.Date();
+
+            assert(
+                Object.getPrototypeOf(date) === Object.getPrototypeOf(date2),
+            );
+
+            assert.equals(Object.getOwnPropertyNames(date).length, 0);
+        });
+
         it("creates Date objects representing clock time", function () {
             const date = new this.clock.Date();
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Fix checks that rely on `Object.getOwnPropertyNames(date)` to behave like native Dates.


#### Background (Problem in detail)  - optional

In our codebase, we use [deep-freeze-es6](https://github.com/christophehurpeau/deep-freeze-es6) to freeze objects containing Date instances. In their code, there is something along the lines `Object.getOwnPropertyNames(dateInstance).forEach(...)` which does nothing for native date instances. When using fake timers, the loop contains exactly one property, namely `constructor`.
The constructor property was added in #511 and fixed for `Object.keys()` in #513.
This PR fixes the same issue as #513 but for `Object.getOwnPropertyNames()` (and related `getOwnProperty*` functions).

#### Solution  - optional
As the fix from #511/#513 only overrides the `constructor` property on the instance without actually changing the real constructor, my fix now sets the constructor property on the prototype class. This has no influence on new instances as `new ClockDate()`.