### PR TITLE
Fix no-DOM Performance type

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepare": "husky",
     "types:build": "tsgo -p tsconfig.types.json",
     "types:check": "tsgo -p tsconfig.types.json --noEmit",
-    "types:smoke": "tsgo -p test/typescript-consumer/tsconfig.json --noEmit"
+    "types:smoke": "tsgo -p test/typescript-consumer/tsconfig.json --noEmit && tsgo -p test/typescript-no-dom-consumer/tsconfig.json --noEmit"
   },
   "types": "./types/fake-timers-src.d.ts",
   "lint-staged": {

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -307,6 +307,10 @@ if (typeof require === "function" && typeof module === "object") {
  */
 
 /**
+ * @typedef {Record<string, any> & { now: () => number }} PerformanceLike
+ */
+
+/**
  * @typedef {object} Timers
  * @property {SetTimeout} setTimeout - native `setTimeout`
  * @property {ClearTimeout} clearTimeout - native `clearTimeout`
@@ -318,7 +322,7 @@ if (typeof require === "function" && typeof module === "object") {
  * @property {ClearImmediate} [clearImmediate] - native `clearImmediate`, if available
  * @property {Hrtime} [hrtime] - native `process.hrtime`, if available
  * @property {NextTick} [nextTick] - native `process.nextTick`, if available
- * @property {Performance} [performance] - native `performance`, if available
+ * @property {PerformanceLike} [performance] - native `performance`, if available
  * @property {RequestAnimationFrame} [requestAnimationFrame] - native `requestAnimationFrame`, if available
  * @property {QueueMicrotask} [queueMicrotask] - whether `queueMicrotask` exists
  * @property {CancelAnimationFrame} [cancelAnimationFrame] - native `cancelAnimationFrame`, if available

--- a/test/typescript-no-dom-consumer/consume-types.ts
+++ b/test/typescript-no-dom-consumer/consume-types.ts
@@ -1,0 +1,16 @@
+import FakeTimers from "@sinonjs/fake-timers";
+
+declare global {
+    class AbortSignal {}
+}
+
+const timers = FakeTimers.timers;
+
+if (timers.performance) {
+    const now: number = timers.performance.now();
+    now.toFixed();
+}
+
+// @ts-expect-error DOM globals should not be available in this consumer.
+const windowRef: Window = {};
+windowRef;

--- a/test/typescript-no-dom-consumer/tsconfig.json
+++ b/test/typescript-no-dom-consumer/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "target": "ESNext",
+    "moduleResolution": "node16",
+    "strict": true,
+    "skipLibCheck": false,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "types": [],
+    "paths": {
+      "@sinonjs/fake-timers": ["../../types/fake-timers-src.d.ts"]
+    }
+  },
+  "include": ["consume-types.ts"]
+}

--- a/types/fake-timers-src.d.ts
+++ b/types/fake-timers-src.d.ts
@@ -95,6 +95,9 @@ export type SetTickModeConfig = {
 export type IntlWithClock = Record<string, any> & {
     clock: Clock;
 };
+export type PerformanceLike = Record<string, any> & {
+    now: () => number;
+};
 export type Timers = {
     setTimeout: SetTimeout;
     clearTimeout: ClearTimeout;
@@ -106,7 +109,7 @@ export type Timers = {
     clearImmediate?: ClearImmediate;
     hrtime?: Hrtime;
     nextTick?: NextTick;
-    performance?: Performance;
+    performance?: PerformanceLike;
     requestAnimationFrame?: RequestAnimationFrame;
     queueMicrotask?: QueueMicrotask;
     cancelAnimationFrame?: CancelAnimationFrame;


### PR DESCRIPTION
fixes #566

## Summary
- replace the DOM Performance reference in generated public types with a structural PerformanceLike type
- add a no-DOM TypeScript smoke consumer with skipLibCheck disabled
- run the new no-DOM smoke fixture as part of types:smoke

## Verification
- npm run types:build
- npm run types:smoke
- npm run types:check
- npm run test-node