### PR TITLE
ci: add types job to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,26 @@ jobs:
               run: |
                   npm run lint
 
+    types:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: "lts/*"
+                  cache: npm
+            - name: Install dependencies
+              run: |
+                  npm ci
+              env:
+                  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 1
+            - name: Type Check
+              run: |
+                  npm run types:check
+            - name: Type Smoke Tests
+              run: |
+                  npm run types:smoke
+
     chromium:
         runs-on: ubuntu-latest
         steps:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run types:check && npm run types:build && npm run types:smoke

--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -174,7 +174,7 @@ if (typeof require === "function" && typeof module === "object") {
  * @property {number} milliseconds - milliseconds component
  * @property {number} microseconds - microseconds component
  * @property {number} nanoseconds - nanoseconds component
- * @property {function({unit: string, relativeTo?: unknown}): number} total - converts to a single unit
+ * @property {(options: {unit: string, relativeTo?: unknown}) => number} total - converts to a single unit
  */
 
 /**
@@ -339,6 +339,7 @@ if (typeof require === "function" && typeof module === "object") {
  * @property {ClearInterval} clearInterval - native `clearInterval`
  * @property {typeof Date} Date - native `Date`
  * @property {typeof Intl} [Intl] - native `Intl`
+ * @property {any} [Temporal] - native `Temporal`
  * @property {SetImmediate} [setImmediate] - native `setImmediate`, if available
  * @property {ClearImmediate} [clearImmediate] - native `clearImmediate`, if available
  * @property {Hrtime} [hrtime] - native `process.hrtime`, if available
@@ -712,12 +713,16 @@ function withGlobal(_global) {
         if (typeof epoch === "number") {
             return epoch;
         }
-        if (typeof epoch.getTime === "function") {
-            return epoch.getTime();
+        if (typeof (/** @type {Date} */ (epoch).getTime) === "function") {
+            return /** @type {Date} */ (epoch).getTime();
         }
-        if (typeof epoch.epochMilliseconds === "number") {
+        if (
+            typeof (
+                /** @type {TemporalTimelike} */ (epoch).epochMilliseconds
+            ) === "number"
+        ) {
             // Temporal.Instant and Temporal.ZonedDateTime both have epochMilliseconds
-            return epoch.epochMilliseconds;
+            return /** @type {TemporalTimelike} */ (epoch).epochMilliseconds;
         }
         throw new TypeError("now should be milliseconds since UNIX epoch");
     }
@@ -1824,7 +1829,7 @@ function withGlobal(_global) {
     const originalSetInterval = _global.setInterval;
 
     /**
-     * @param {Date|number} [start] the system time - non-integer values are floored
+     * @param {Date|number|TemporalTimelike} [start] the system time - non-integer values are floored
      * @param {number} [loopLimit] maximum number of timers that will be run when calling runAll()
      * @returns {Clock}
      */
@@ -2174,11 +2179,14 @@ function withGlobal(_global) {
                 isPresent.Temporal &&
                 tickValue !== null &&
                 typeof tickValue === "object" &&
-                typeof tickValue.total === "function"
+                typeof (/** @type {TemporalDuration} */ (tickValue).total) ===
+                    "function"
             ) {
-                return durationToMs(tickValue);
+                return durationToMs(
+                    /** @type {TemporalDuration} */ (tickValue),
+                );
             }
-            return parseTime(tickValue);
+            return parseTime(/** @type {string} */ (tickValue));
         }
 
         /**
@@ -2347,7 +2355,7 @@ function withGlobal(_global) {
         }
 
         /**
-         * @param {number|string} tickValue milliseconds or a string parseable by parseTime
+         * @param {number|string|TemporalDuration} tickValue milliseconds or a string parseable by parseTime
          * @param {boolean} isAsync whether this is an async tick
          * @param {FakeTimersFunction} [resolve] promise resolve function
          * @param {FakeTimersFunction} [reject] promise reject function

--- a/types/fake-timers-src.d.ts
+++ b/types/fake-timers-src.d.ts
@@ -35,9 +35,6 @@ export type CancelIdleCallback = (id: TimerId) => void;
 export type ClearImmediate = (id: NodeImmediate) => void;
 export type CountTimers = () => number;
 export type RunMicrotasks = () => void;
-export type TemporalTimelike = {
-    epochMilliseconds: number;
-};
 export type TemporalDuration = {
     years: number;
     months: number;
@@ -49,7 +46,13 @@ export type TemporalDuration = {
     milliseconds: number;
     microseconds: number;
     nanoseconds: number;
-    total(options: { unit: string; relativeTo?: unknown }): number;
+    total: (options: {
+        unit: string;
+        relativeTo?: unknown;
+    }) => number;
+};
+export type TemporalTimelike = {
+    epochMilliseconds: number;
 };
 export type Tick = (tickValue: number | string | TemporalDuration) => number;
 export type TickAsync = (tickValue: number | string | TemporalDuration) => Promise<number>;


### PR DESCRIPTION
Ensure types:check and types:smoke are run during CI. Type validation
was previously only in posttest, which was bypassed by individual CI jobs.

This made us miss that the Temporal PR (#569) had breaking types 😑

Having a dedicated step should avoid that in the future.
