### PR TITLE
fix: accept duck-typed `TemporalDuration` when `Temporal` absent from global

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -2085,10 +2085,18 @@ function withGlobal(_global) {
         function durationToMs(duration) {
             // relativeTo uses the real system timezone — fake-timers fakes time, not place.
             // Calendar-unit durations (months, years) will resolve DST/length using the host tz.
-            const relativeTo = NativeTemporal.Instant.fromEpochMilliseconds(
-                clock.now,
-            ).toZonedDateTimeISO(NativeTemporal.Now.timeZoneId());
-            return duration.total({ unit: "millisecond", relativeTo });
+            // When NativeTemporal is absent (duck-typed duration in a Temporal-free env),
+            // omit relativeTo; calendar-unit durations will throw from within .total() itself.
+            const opts =
+                /** @type {{ unit: string, relativeTo?: unknown }} */ ({
+                    unit: "millisecond",
+                });
+            if (NativeTemporal) {
+                opts.relativeTo = NativeTemporal.Instant.fromEpochMilliseconds(
+                    clock.now,
+                ).toZonedDateTimeISO(NativeTemporal.Now.timeZoneId());
+            }
+            return duration.total(opts);
         }
 
         /**
@@ -2100,7 +2108,6 @@ function withGlobal(_global) {
                 return tickValue;
             }
             if (
-                isPresent.Temporal &&
                 tickValue !== null &&
                 typeof tickValue === "object" &&
                 typeof (/** @type {TemporalDuration} */ (tickValue).total) ===

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -6637,6 +6637,16 @@ describe("missing timers", function () {
             assert.isUndefined(clock.Temporal);
             clock.uninstall();
         });
+
+        it("tick() accepts a TemporalDuration-shaped object even when Temporal is absent from the global", function () {
+            const clock = FakeTimers.createClock(0);
+            // duck-typed Duration: total("millisecond") returns ms, no native Temporal required
+            const duration = {
+                total: ({ unit }) => (unit === "millisecond" ? 5000 : 5),
+            };
+            clock.tick(duration);
+            assert.equals(clock.now, 5000);
+        });
     });
 
     describe("Temporal.Now", function () {


### PR DESCRIPTION
I tried to use the new `Temporal` stuff in Jest, and hit this 😀

`tickValueToMs` gated the `Duration` duck-type check behind `isPresent.Temporal`, so any object with a `.total()` method fell through to `parseTime()` and threw `TypeError: str.split is not a function` when Temporal was absent from the faked global.

The guard doesn't belong here. Accepting a Duration as input to `tick()` is purely duck-typed - `durationToMs` just calls `duration.total(...)`, it has no dependency on the native Temporal global. The `isPresent.Temporal` guard is correct for faking `Temporal.Now.*` (which has to construct real Temporal objects as return values), not for accepting input.

Two changes:
- Remove `isPresent.Temporal &&` from the duck-type check in `tickValueToMs`
- Make `durationToMs` omit `relativeTo` when `NativeTemporal` is unavailable — calendar-unit durations will throw from within `.total()` itself, which is the right place for that error

`tick()`, `tickAsync()`, and `jump()` all go through `tickValueToMs` so all three get the fix.
