### PR TITLE
fix: do not shadow Object.prototype.hasOwnProperty on installed globals

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1629,7 +1629,11 @@ function withGlobal(_global) {
      * @param {Clock} clock
      */
     function hijackMethod(target, method, clock) {
-        clock[method].hasOwnProperty = Object.prototype.hasOwnProperty.call(
+        // Intentional non-conflicting key: storing this flag under
+        // `hasOwnProperty` would shadow the inherited Object.prototype
+        // method on the fake function and break callers that run
+        // `setTimeout.hasOwnProperty(name)` on the installed global.
+        clock[method].hadOwnProperty = Object.prototype.hasOwnProperty.call(
             target,
             method,
         );
@@ -2615,7 +2619,7 @@ function withGlobal(_global) {
                             _global[method] = clock[`_${method}`];
                         }
                     } else {
-                        if (clock[method] && clock[method].hasOwnProperty) {
+                        if (clock[method] && clock[method].hadOwnProperty) {
                             _global[method] = clock[`_${method}`];
                         } else {
                             try {

--- a/test/issue-549-test.js
+++ b/test/issue-549-test.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const { FakeTimers, assert } = require("./helpers/setup-tests");
+
+describe("issue #549 - hijacked methods retain inherited hasOwnProperty", function () {
+    let clock;
+
+    afterEach(function () {
+        if (clock) {
+            clock.uninstall();
+            clock = undefined;
+        }
+    });
+
+    // PR #549 renamed the install-time bookkeeping flag from `hadOwnProperty`
+    // to `hasOwnProperty`. The new name shadows the inherited Object.prototype
+    // method on each fake function, so any caller that runs
+    // `setTimeout.hasOwnProperty(name)` on the installed global crashes with
+    // `TypeError: ... is not a function`.
+    it("does not shadow Object.prototype.hasOwnProperty on hijacked globals", function () {
+        clock = FakeTimers.install();
+
+        assert.isFunction(globalThis.setTimeout.hasOwnProperty);
+        assert.isFunction(globalThis.setInterval.hasOwnProperty);
+        assert.isFunction(globalThis.clearTimeout.hasOwnProperty);
+        assert.isFunction(globalThis.clearInterval.hasOwnProperty);
+        assert.isFunction(globalThis.Date.hasOwnProperty);
+
+        assert.isTrue(globalThis.setTimeout.hasOwnProperty("name"));
+        assert.isFalse(globalThis.setTimeout.hasOwnProperty("definitelyNot"));
+    });
+});

--- a/test/typescript-consumer/consume-types.ts
+++ b/test/typescript-consumer/consume-types.ts
@@ -19,7 +19,7 @@ installedClock.setTickMode({ mode: "interval", delta: 50 });
 
 installedClock.uninstall();
 
-const withGlobal = FakeTimers.withGlobal({});
+const withGlobal = FakeTimers.withGlobal({ Date });
 const anotherClock = withGlobal.createClock(1000);
 anotherClock.next();
 anotherClock.nextAsync().then((now: number) => console.log(now));

--- a/types/fake-timers-src.d.ts
+++ b/types/fake-timers-src.d.ts
@@ -251,7 +251,435 @@ export type NodeImmediate = {
     ref: NodeImmediateRef;
     unref: NodeImmediateUnref;
 };
+/**
+ * @typedef {"nextAsync" | "manual" | "interval"} TickMode
+ */
+/**
+ * @typedef {object} NextAsyncTickMode
+ * @property {"nextAsync"} mode - runs timers one macrotask at a time
+ */
+/**
+ * @typedef {object} ManualTickMode
+ * @property {"manual"} mode - advances only when the caller explicitly ticks
+ */
+/**
+ * @typedef {object} IntervalTickMode
+ * @property {"interval"} mode - advances automatically on a native interval
+ * @property {number} [delta] - interval duration in milliseconds
+ */
+/**
+ * @typedef {IntervalTickMode | NextAsyncTickMode | ManualTickMode} TimerTickMode
+ */
+/**
+ * @callback FakeTimersFunction
+ * @param {...unknown[]} args
+ * @returns {unknown}
+ */
+/**
+ * @callback VoidVarArgsFunc
+ * @param {...unknown[]} args - optional arguments to call the callback with
+ * @returns {void}
+ */
+/**
+ * @callback NextTick
+ * @param {VoidVarArgsFunc} callback - the callback to run
+ * @param {...unknown[]} args - optional arguments to call the callback with
+ * @returns {void}
+ */
+/**
+ * @callback SetImmediate
+ * @param {VoidVarArgsFunc} callback - the callback to run
+ * @param {...unknown[]} args - optional arguments to call the callback with
+ * @returns {NodeImmediate}
+ */
+/**
+ * @callback SetTimeout
+ * @param {VoidVarArgsFunc} callback - the callback to run
+ * @param {number} [delay] - optional delay in milliseconds
+ * @param {...unknown[]} args - optional arguments to call the callback with
+ * @returns {TimerId} - the timeout identifier
+ */
+/**
+ * @callback ClearTimeout
+ * @param {TimerId} [id] - the timeout identifier to clear
+ * @returns {void}
+ */
+/**
+ * @callback SetInterval
+ * @param {VoidVarArgsFunc} callback - the callback to run
+ * @param {number} [delay] - optional delay in milliseconds
+ * @param {...unknown[]} args - optional arguments to call the callback with
+ * @returns {TimerId} - the interval identifier
+ */
+/**
+ * @callback ClearInterval
+ * @param {TimerId} [id] - the interval identifier to clear
+ * @returns {void}
+ */
+/**
+ * @callback QueueMicrotask
+ * @param {VoidVarArgsFunc} callback - the callback to run
+ * @returns {void}
+ */
+/**
+ * @callback TimeRemaining
+ * @returns {number}
+ */
+/**
+ * @typedef {object} IdleDeadline
+ * @property {boolean} didTimeout - whether or not the callback was called before reaching the optional timeout
+ * @property {TimeRemaining} timeRemaining - a floating-point value providing an estimate of the number of milliseconds remaining in the current idle period
+ */
+/**
+ * @callback RequestIdleCallbackCallback
+ * @param {IdleDeadline} deadline
+ */
+/**
+ * Queues a function to be called during a browser's idle periods
+ * @callback RequestIdleCallback
+ * @param {RequestIdleCallbackCallback} callback
+ * @param {{timeout?: number}} [options] - an options object
+ * @returns {number} the id
+ */
+/**
+ * @callback AnimationFrameCallback
+ * @param {number} timestamp
+ */
+/**
+ * @callback RequestAnimationFrame
+ * @param {AnimationFrameCallback} callback
+ * @returns {TimerId} - the request id
+ */
+/**
+ * @callback CancelAnimationFrame
+ * @param {TimerId} id - cancels a frame callback
+ * @returns {void}
+ */
+/**
+ * @callback CancelIdleCallback
+ * @param {TimerId} id - cancels a scheduled idle callback
+ * @returns {void}
+ */
+/**
+ * @callback ClearImmediate
+ * @param {NodeImmediate} id - faked `clearImmediate`
+ * @returns {void}
+ */
+/**
+ * @callback CountTimers
+ * @returns {number}
+ */
+/**
+ * @callback RunMicrotasks
+ * @returns {void}
+ */
+/**
+ * @typedef {object} TemporalDuration
+ * @property {number} years - years component
+ * @property {number} months - months component
+ * @property {number} weeks - weeks component
+ * @property {number} days - days component
+ * @property {number} hours - hours component
+ * @property {number} minutes - minutes component
+ * @property {number} seconds - seconds component
+ * @property {number} milliseconds - milliseconds component
+ * @property {number} microseconds - microseconds component
+ * @property {number} nanoseconds - nanoseconds component
+ * @property {(options: {unit: string, relativeTo?: unknown}) => number} total - converts to a single unit
+ */
+/**
+ * @typedef {object} TemporalTimelike
+ * @property {number} epochMilliseconds - milliseconds since the Unix epoch (present on Temporal.Instant and Temporal.ZonedDateTime)
+ */
+/**
+ * @callback Tick
+ * @param {number|string|TemporalDuration} tickValue milliseconds, a string parseable by parseTime, or a Temporal.Duration
+ * @returns {number} will return the new `now` value
+ */
+/**
+ * @callback TickAsync
+ * @param {number|string|TemporalDuration} tickValue milliseconds, a string parseable by parseTime, or a Temporal.Duration
+ * @returns {Promise<number>}
+ */
+/**
+ * @callback Next
+ * @returns {number}
+ */
+/**
+ * @callback NextAsync
+ * @returns {Promise<number>}
+ */
+/**
+ * @callback RunAll
+ * @returns {number}
+ */
+/**
+ * @callback RunToFrame
+ * @returns {number}
+ */
+/**
+ * @callback RunAllAsync
+ * @returns {Promise<number>}
+ */
+/**
+ * @callback RunToLast
+ * @returns {number}
+ */
+/**
+ * @callback RunToLastAsync
+ * @returns {Promise<number>}
+ */
+/**
+ * @callback Reset
+ * @returns {void}
+ */
+/**
+ * @callback SetSystemTime
+ * @param {number|Date|TemporalTimelike} [now] initial mocked time, as milliseconds since epoch, a Date, a Temporal.Instant, or a Temporal.ZonedDateTime
+ * @returns {void}
+ */
+/**
+ * @callback Jump
+ * @param {number|string|TemporalDuration} tickValue milliseconds, a human-readable value like "01:11:15", or a Temporal.Duration
+ * @returns {number}
+ */
+/**
+ * @callback Uninstall
+ * @returns {void}
+ */
+/**
+ * @callback SetTickMode
+ * @param {SetTickModeConfig} tickModeConfig - The new configuration for how the clock should tick.
+ * @returns {void}
+ */
+/**
+ * @callback Hrtime
+ * @param {Array<number>} [prev]
+ * @returns {Array<number>}
+ */
+/**
+ * @callback WithGlobal
+ * @param {object} _global Namespace to mock (e.g. `window`)
+ * @returns {FakeTimers}
+ */
+/**
+ * @typedef {"setTimeout" | "clearTimeout" | "setImmediate" | "clearImmediate" | "setInterval" | "clearInterval" | "Date" | "nextTick" | "hrtime" | "requestAnimationFrame" | "cancelAnimationFrame" | "requestIdleCallback" | "cancelIdleCallback" | "performance" | "queueMicrotask" | "Intl" | "Temporal"} FakeMethod
+ */
+/**
+ * @typedef {number | NodeImmediate | Timer} TimerId
+ */
+/**
+ * @typedef {Record<string, any> & {
+ *   setTimeout?: SetTimeout,
+ *   clearTimeout?: ClearTimeout,
+ *   setInterval?: SetInterval,
+ *   clearInterval?: ClearInterval,
+ *   setImmediate?: SetImmediate,
+ *   clearImmediate?: ClearImmediate,
+ *   queueMicrotask?: QueueMicrotask,
+ *   requestAnimationFrame?: RequestAnimationFrame,
+ *   cancelAnimationFrame?: CancelAnimationFrame,
+ *   requestIdleCallback?: RequestIdleCallback,
+ *   cancelIdleCallback?: CancelIdleCallback,
+ *   process?: any,
+ *   performance?: any,
+ *   Performance?: any,
+ *   Intl?: any,
+ *   Temporal?: any,
+ *   Promise?: typeof Promise,
+ *   Date: typeof Date & { isFake?: boolean, toSource?: () => string, clock?: any }
+ * }} GlobalObject
+ */
+/**
+ * @typedef {object} TimerHeap
+ * @property {Timer[]} timers - the heap-ordered timers
+ * @property {() => Timer | undefined} peek - returns the next timer without removing it
+ * @property {(timer: Timer) => void} push - adds a timer to the heap
+ * @property {() => Timer | undefined} pop - removes and returns the next timer
+ * @property {(timer: Timer) => void} remove - removes a specific timer
+ */
+/**
+ * @typedef {object} ClockTickMode
+ * @property {TickMode} mode - active tick mode
+ * @property {number} counter - increments whenever the mode changes
+ * @property {number} [delta] - interval length in milliseconds
+ */
+/**
+ * @typedef {object} SetTickModeConfig
+ * @property {TickMode} mode - desired tick mode
+ * @property {number} [delta] - interval length in milliseconds
+ */
+/**
+ * @typedef {Record<string, any> & { clock: Clock }} IntlWithClock
+ */
+/**
+ * @typedef {Record<string, any> & { now: () => number }} PerformanceLike
+ */
+/**
+ * @typedef {object} Timers
+ * @property {SetTimeout} setTimeout - native `setTimeout`
+ * @property {ClearTimeout} clearTimeout - native `clearTimeout`
+ * @property {SetInterval} setInterval - native `setInterval`
+ * @property {ClearInterval} clearInterval - native `clearInterval`
+ * @property {typeof Date} Date - native `Date`
+ * @property {typeof Intl} [Intl] - native `Intl`
+ * @property {any} [Temporal] - native `Temporal`
+ * @property {SetImmediate} [setImmediate] - native `setImmediate`, if available
+ * @property {ClearImmediate} [clearImmediate] - native `clearImmediate`, if available
+ * @property {Hrtime} [hrtime] - native `process.hrtime`, if available
+ * @property {NextTick} [nextTick] - native `process.nextTick`, if available
+ * @property {PerformanceLike} [performance] - native `performance`, if available
+ * @property {RequestAnimationFrame} [requestAnimationFrame] - native `requestAnimationFrame`, if available
+ * @property {QueueMicrotask} [queueMicrotask] - whether `queueMicrotask` exists
+ * @property {CancelAnimationFrame} [cancelAnimationFrame] - native `cancelAnimationFrame`, if available
+ * @property {RequestIdleCallback} [requestIdleCallback] - native `requestIdleCallback`, if available
+ * @property {CancelIdleCallback} [cancelIdleCallback] - native `cancelIdleCallback`, if available
+ */
+/**
+ * @typedef {object} ClockState
+ * @property {number} tickFrom - lower bound of the current tick range
+ * @property {number} tickTo - upper bound of the current tick range
+ * @property {number} [previous] - previous timer time used during ticking
+ * @property {number | null} [oldNow] - previous value of `now`
+ * @property {Timer} [timer] - timer currently being processed
+ * @property {unknown} [firstException] - first exception raised while processing timers
+ * @property {number} [nanosTotal] - accumulated nanoseconds from fractional ticks
+ * @property {number} [msFloat] - accumulated fractional milliseconds
+ * @property {number} [ms] - accumulated whole milliseconds
+ */
+/**
+ * @typedef {object} TimerInitialProps
+ * @property {VoidVarArgsFunc} func - callback or string to execute
+ * @property {unknown[]} [args] - arguments passed to the callback
+ * @property {'Timeout' | 'Interval' | 'Immediate' | 'AnimationFrame' | 'IdleCallback'} [type] - timer kind
+ * @property {number} [delay] - requested delay in milliseconds
+ * @property {number} [callAt] - scheduled execution time
+ * @property {number} [createdAt] - time at which the timer was created
+ * @property {boolean} [immediate] - whether this timer should run before non-immediate timers at the same time
+ * @property {number} [id] - unique timer identifier
+ * @property {Error} [error] - captured stack for loop diagnostics
+ * @property {number} [interval] - interval for repeated timers
+ * @property {boolean} [animation] - whether this is an animation frame timer
+ * @property {boolean} [requestIdleCallback] - whether this is an idle callback timer
+ * @property {number} [order] - execution order for timers at the same time
+ * @property {number} [heapIndex] - index in the timer heap
+ */
+/**
+ * @callback CreateClockCallback
+ * @param {number|Date|TemporalTimelike} [start] initial mocked time, as milliseconds since epoch, a Date, a Temporal.Instant, or a Temporal.ZonedDateTime
+ * @param {number} [loopLimit] maximum number of timers run before aborting with an infinite-loop error
+ * @returns {Clock}
+ */
+/**
+ * @callback InstallCallback
+ * @param {Config} [config] Optional config
+ * @returns {Clock}
+ */
+/**
+ * @typedef {object} FakeTimers
+ * @property {Timers} timers - the native timer APIs saved for later restoration
+ * @property {CreateClockCallback} createClock - creates a new fake clock
+ * @property {InstallCallback} install - installs the fake timers onto the default global object
+ * @property {WithGlobal} withGlobal - creates a fake-timers instance for a provided global object
+ */
+/**
+ * @typedef {object} Clock
+ * @property {number} now - current mocked time in milliseconds
+ * @property {typeof Date & {clock?: Clock, isFake?: boolean, toSource?: () => string}} Date - fake Date constructor bound to this clock
+ * @property {number} loopLimit - maximum number of timers before assuming an infinite loop
+ * @property {RequestIdleCallback} requestIdleCallback - schedules an idle callback
+ * @property {CancelIdleCallback} cancelIdleCallback - cancels a scheduled idle callback
+ * @property {SetTimeout} setTimeout - faked `setTimeout`
+ * @property {ClearTimeout} clearTimeout - faked `clearTimeout`
+ * @property {NextTick} nextTick - faked `process.nextTick`
+ * @property {QueueMicrotask} queueMicrotask - faked `queueMicrotask`
+ * @property {SetInterval} setInterval - faked `setInterval`
+ * @property {ClearInterval} clearInterval - faked `clearInterval`
+ * @property {SetImmediate} setImmediate - faked `setImmediate`
+ * @property {ClearImmediate} clearImmediate - faked `clearImmediate`
+ * @property {CountTimers} countTimers - counts scheduled timers
+ * @property {RequestAnimationFrame} requestAnimationFrame - schedules a frame callback
+ * @property {CancelAnimationFrame} cancelAnimationFrame - cancels a frame callback
+ * @property {RunMicrotasks} runMicrotasks - drains microtasks
+ * @property {Tick} tick - advances fake time synchronously
+ * @property {TickAsync} tickAsync - advances fake time asynchronously
+ * @property {Next} next - runs the next scheduled timer
+ * @property {NextAsync} nextAsync - runs the next scheduled timer asynchronously
+ * @property {RunAll} runAll - runs all scheduled timers
+ * @property {RunToFrame} runToFrame - runs timers up to the next animation frame
+ * @property {RunAllAsync} runAllAsync - runs all scheduled timers asynchronously
+ * @property {RunToLast} runToLast - runs timers up to the last scheduled timer
+ * @property {RunToLastAsync} runToLastAsync - runs timers up to the last scheduled timer asynchronously
+ * @property {Reset} reset - clears all timers and resets the clock
+ * @property {SetSystemTime} setSystemTime - sets the clock to a specific wall-clock time
+ * @property {Jump} jump - advances time and returns the new `now`
+ * @property {any} performance - fake performance object
+ * @property {Hrtime} hrtime - faked `process.hrtime`
+ * @property {Uninstall} uninstall - restores native timers
+ * @property {string[]} methods - names of faked methods
+ * @property {boolean} [shouldClearNativeTimers] - inherited from config
+ * @property {{methodName:string, original:unknown}[] | undefined} timersModuleMethods - saved Node timers module methods
+ * @property {{methodName:string, original:unknown}[] | undefined} timersPromisesModuleMethods - saved Node timers/promises methods
+ * @property {Map<VoidVarArgsFunc, AbortSignal>} abortListenerMap - active abort listeners
+ * @property {SetTickMode} setTickMode - switches the auto-tick mode
+ * @property {Map<number, Timer>} [timers] - internal timer storage
+ * @property {TimerHeap} [timerHeap] - internal timer heap
+ * @property {boolean} [duringTick] - internal flag
+ * @property {boolean} isNearInfiniteLimit - internal flag indicating the loop limit is nearly reached
+ * @property {TimerId} [attachedInterval] - internal flag
+ * @property {ClockTickMode} [tickMode] - internal flag
+ * @property {Timer[]} [jobs] - internal flag
+ * @property {IntlWithClock} [Intl] - fake Intl object
+ * @property {any} [Temporal] - fake Temporal object
+ */
+/**
+ * Configuration object for the `install` method.
+ * @typedef {object} Config
+ * @property {number|Date|TemporalTimelike} [now] initial mocked time, as milliseconds since epoch, a Date, a Temporal.Instant, or a Temporal.ZonedDateTime
+ * @property {FakeMethod[]} [toFake] method names that should be faked
+ * @property {FakeMethod[]} [toNotFake] method names that should remain native
+ * @property {number} [loopLimit] maximum number of timers run before aborting with an infinite-loop error
+ * @property {boolean} [shouldAdvanceTime] automatically increments mocked time while the clock is installed
+ * @property {number} [advanceTimeDelta] interval in milliseconds used when `shouldAdvanceTime` is enabled
+ * @property {boolean} [shouldClearNativeTimers] forwards clear calls to native methods when the timer is not fake
+ * @property {boolean} [ignoreMissingTimers] suppresses errors when a requested timer is missing from the global object
+ * @property {GlobalObject} [target] global object to install onto
+ */
+/**
+ * The internal structure to describe a scheduled fake timer
+ * @typedef {TimerInitialProps} Timer
+ * @property {unknown[]} args - arguments passed to the callback
+ * @property {number} callAt - scheduled execution time
+ * @property {number} createdAt - time at which the timer was created
+ * @property {number} id - unique timer identifier
+ * @property {'Timeout' | 'Interval' | 'Immediate' | 'AnimationFrame' | 'IdleCallback'} type - timer kind
+ */
+/**
+ * @callback NodeImmediateHasRef
+ * @returns {boolean}
+ */
+/**
+ * @callback NodeImmediateRef
+ * @returns {NodeImmediate}
+ */
+/**
+ * @callback NodeImmediateUnref
+ * @returns {NodeImmediate}
+ */
+/**
+ * A Node timer
+ * @typedef {object} NodeImmediate
+ * @property {NodeImmediateHasRef} hasRef - reports whether the timer keeps the event loop alive
+ * @property {NodeImmediateRef} ref - marks the timer as referenced
+ * @property {NodeImmediateUnref} unref - marks the timer as unreferenced
+ */
+/**
+ * Mocks available features in the specified global namespace.
+ * @param {GlobalObject} _global Namespace to mock (e.g. `window`)
+ * @returns {FakeTimers}
+ */
+declare function withGlobal(_global: GlobalObject): FakeTimers;
 export declare var timers: Timers;
 export declare var createClock: CreateClockCallback;
 export declare var install: InstallCallback;
-export declare var withGlobal: WithGlobal;
+export { withGlobal };


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

The install-time bookkeeping flag has to live under a key that does not
collide with `Object.prototype.hasOwnProperty`. Storing it as
`hasOwnProperty` shadows the inherited method on each fake function, so
any caller that runs `setTimeout.hasOwnProperty(name)` after `install()`
crashes with `TypeError: ... is not a function`.

Refs: #549
