### PR TITLE
Remove spurious disable of ESLint

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -2621,7 +2621,7 @@ function withGlobal(_global) {
                             try {
                                 delete _global[method];
                             } catch {
-                                /* eslint no-empty: "off" */
+                                // ignored
                             }
                         }
                     }


### PR DESCRIPTION
#### Purpose (TL;DR)

Remove an `eslint-disable` that (1) was unnecessary (2) disabled the rule for the whole rest of the file (likely accidental).

#### Background (Problem in detail)

ESLint's [no-empty] rule disallows empty `catch` blocks. For example, this is a violation:

```javascript
try {
    // do something
} catch {}
```

In one spot, the code avoided this violation with something like this:

```javascript
try {
    // do something
} catch {
    /* eslint no-empty: "off" */
}
```

This workaround has three problems:

1. It's overzealous: this form disables the rule for that line _and for the rest of the file_, which is probably more than was intended.
1. It's unnecessary: an `// ignored` comment removes an unneeded ESLint suppression.
1. It's inconsistent: other spots use `// ignored` or `// noop` instead.

#### Solution

Instead of disabling ESLint, use an `// ignored` comment, like is done elsewhere.

[no-empty]: https://eslint.org/docs/latest/rules/no-empty
