### PR TITLE
fix: keep setInterval recurring when the interval is not finite

### DIFF
--- a/src/fake-timers-src.js
+++ b/src/fake-timers-src.js
@@ -1296,6 +1296,9 @@ function withGlobal(_global) {
 
         if (Object.prototype.hasOwnProperty.call(timer, "interval")) {
             timer.type = "Interval";
+            if (!isNumberFinite(timer.interval)) {
+                timer.interval = 1;
+            }
             timer.interval = timer.interval > maxTimeout ? 1 : timer.interval;
         }
 

--- a/test/fake-timers-test.js
+++ b/test/fake-timers-test.js
@@ -3207,6 +3207,16 @@ describe("FakeTimers", function () {
             assert.equals(stub.callCount, 9);
         });
 
+        it("keeps recurring when the interval is not finite", function () {
+            // Node and browsers clamp a non-finite interval to 1ms and keep
+            // repeating; the timer must not fire only once and then die.
+            const stub = sinon.stub();
+            this.clock.setInterval(stub, NaN);
+            this.clock.tick(5);
+
+            assert.equals(stub.callCount, 6);
+        });
+
         it("is not influenced by forward system clock changes", function () {
             const stub = sinon.stub();
             this.clock.setInterval(stub, 10);


### PR DESCRIPTION
## Problem

`setInterval()` with a non-finite delay (`NaN`, `undefined`, a non-numeric string, `Infinity`) fires **exactly once and then dies**, instead of repeating.

Real Node and browsers clamp a non-finite interval to 1ms and keep firing (Node even emits a `TimeoutNaNWarning: NaN is not a number. Timeout duration was set to 1.`).

### Repro

```js
const clock = require("@sinonjs/fake-timers").createClock(0);
const fires = [];
let c = 0, id;
id = clock.setInterval(() => {
    fires.push(clock.now);
    if (++c >= 3) clock.clearInterval(id);
}, NaN);
clock.tick(20);

// real Node (oracle): the interval repeats every ~1ms -> fires 3 times
// fake-timers (before this fix): [0]  <- one fire, timer dead
```

Real-Node oracle for the same callback:

```
TimeoutNaNWarning: NaN is not a number. Timeout duration was set to 1.
real Node NaN interval fired 3 times, deltas: [ 3, 4, 5 ]
```

## Root cause

In `addTimer` (`src/fake-timers-src.js`) the **delay** branch already guards non-finite values:

```js
if (!isNumberFinite(timer.delay)) {
    timer.delay = 0;
}
timer.delay = timer.delay > maxTimeout ? 1 : timer.delay;
```

but the sibling **interval** branch only handled the `> maxTimeout` case:

```js
timer.interval = timer.interval > maxTimeout ? 1 : timer.interval;
```

Since `NaN > maxTimeout` is `false`, `timer.interval` stays `NaN`. On each re-schedule `callTimer` does `timer.callAt += timer.interval`, i.e. `callAt += NaN -> NaN`, after which `inRange` is never true again, so the timer is dropped after a single call.

## Fix

Mirror the delay-branch guard in the interval branch, clamping a non-finite interval to Node's effective value of `1`ms:

```js
if (!isNumberFinite(timer.interval)) {
    timer.interval = 1;
}
```

This makes the interval branch consistent with the long-standing delay-branch behavior and matches the real platform clamp.

## Tests

Added a red/green test in the `setInterval` block:

- Before the fix: `setInterval(stub, NaN)` then `tick(5)` -> `callCount === 1` (fires once, dies).
- After the fix: same -> `callCount === 6` (fires at 0,1,2,3,4,5, i.e. keeps recurring at the clamped 1ms interval).

Full Node suite green: `494 passing` (493 baseline + the new test), `0 failing`. `eslint` and `prettier --check` clean on the changed files.